### PR TITLE
Add a feature for a `region` CodeList

### DIFF
--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -35,13 +35,16 @@ class CodeList(Mapping):
 
         Parameters
         ----------
-        path
-        file
-        top_level_attr
+        path: :class:`pathlib.Path`
+            The path to a folder with yaml files of a suitable structure.
+        file: str, optional
+            Passed to :code:`path.glob()`, defaults to "**/*" (all files in subfolders).
+        top_level_attr: str, optional
+            Converting the top-level key in dictionaries to an attribute of the codes.
 
         Returns
         -------
-        Nomenclature
+        CodeList
         """
         parse_yaml(path=path, codes=self, file=file, top_level_attr=top_level_attr)
         return self  # allows to do `foo = CodeList("foo").parse_files(path)`

--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -30,7 +30,18 @@ class CodeList(Mapping):
     def __repr__(self):
         return self._codes.__repr__()
 
-    def parse_files(self, path, file=None):
-        """Parse all files in `path` and add them to the codelist"""
-        parse_yaml(path=path, codes=self, file=file)
+    def parse_files(self, path, file=None, top_level_attr=None):
+        """Parse all files in `path` and add them to the codelist
+
+        Parameters
+        ----------
+        path
+        file
+        top_level_attr
+
+        Returns
+        -------
+        Nomenclature
+        """
+        parse_yaml(path=path, codes=self, file=file, top_level_attr=top_level_attr)
         return self  # allows to do `foo = CodeList("foo").parse_files(path)`

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from nomenclature.codes import CodeList
 
 
-class Nomenclature():
+class Nomenclature:
     """A nomenclature with codelists for all dimensions used in the IAMC data format"""
 
     def __init__(self, path="definitions"):
@@ -10,3 +10,6 @@ class Nomenclature():
             path = Path(path)
 
         self.variable = CodeList("variable").parse_files(path / "variables")
+        self.region = CodeList("region").parse_files(
+            path / "regions", top_level_attr="hierarchy"
+        )

--- a/nomenclature/utils.py
+++ b/nomenclature/utils.py
@@ -2,7 +2,7 @@ import re
 import yaml
 
 
-def parse_yaml(path, codes, file=None, ext=".yaml"):
+def parse_yaml(path, codes, file=None, ext=".yaml", top_level_attr=None):
     """Parse `file` in `path` (or all files in subfolders if `file=None`)"""
     new_codes, tag_dict = [], {}
 
@@ -19,12 +19,20 @@ def parse_yaml(path, codes, file=None, ext=".yaml"):
                 if list(_dct)[0] in tag_dict:
                     raise ValueError(f"Duplicate tag: {list(_dct)[0]}")
                 tag_dict.update(_dct)
+                continue
 
-            # else, add `file` attribute to each element and add to main dictionary
-            else:
-                for key, value in _dct.items():
-                    value["file"] = str(f)
-                new_codes.append(_dct)
+            # if specified, set top-level key as attribute instead
+            if top_level_attr is not None:
+                _original_dict, _dct = _dct.copy(), dict()
+                for top_key, _codes in _original_dict.items():
+                    for code, attributes in _codes.items():
+                        attributes[top_level_attr] = top_key
+                        _dct[code] = attributes
+
+            # add `file` attribute to each element and add to main dictionary
+            for key, value in _dct.items():
+                value["file"] = str(f)
+            new_codes.append(_dct)
 
     return replace_tags(codes, new_codes, tag_dict)
 

--- a/tests/data/region_codelist/region.yaml
+++ b/tests/data/region_codelist/region.yaml
@@ -1,0 +1,7 @@
+common:
+  World:
+    definition: The entire world
+countries:
+  Some Country:
+    iso2: XY
+    iso3: XYZ

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -32,3 +32,17 @@ def test_tagged_codelist():
     d = "Final energy consumption of renewables in the industrial sector"
     assert v in code
     assert code[v]["definition"] == d
+
+
+def test_region_codelist():
+    """Check replacing top-level hierarchy of yaml file as attribute for regions"""
+    code = CodeList("region").parse_files(
+        TEST_DATA_DIR / "region_codelist", top_level_attr="hierarchy",
+    )
+
+    assert "World" in code
+    assert code["World"]["hierarchy"] == "common"
+
+    assert "Some Country" in code
+    assert code["Some Country"]["hierarchy"] == "countries"
+    assert code["Some Country"]["iso2"] == "XY"


### PR DESCRIPTION
The `region` CodeList has a slightly different structure of the yaml files: to avoid repeating a "hierarchy" attribute many times (e.g., is this a country or a continent), the yaml files have a structure like
```yaml
<Hierarchy>:
  Region Code:
    Attribute: Attribute value
```
See the added unit test for a more applied example.
