### PR TITLE
Feature to create yaml from xlsx

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from nomenclature.utils import *
 from nomenclature.codes import CodeList
-from nomenclature.core import Nomenclature
+from nomenclature.core import Nomenclature, create_yaml_from_xlsx
 from nomenclature.testing import assert_valid_yaml
 
 

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import pandas as pd
+import yaml
+
 from pyam import IamDataFrame
 from nomenclature.codes import CodeList
 from nomenclature.validation import validate
@@ -37,3 +40,29 @@ class Nomenclature:
             If `df` fails validation against any codelist.
         """
         validate(self, df)
+
+
+def create_yaml_from_xlsx(source, target, sheet_name, col, attrs=[]):
+    """Parses an xlsx file with a codelist and writes a yaml file
+
+    Parameters
+    ----------
+    source : str, path, file-like object
+        Path to Excel file with definitions (codelists).
+    target : str, path, file-like object
+        Path to save the parsed definitions as yaml file.
+    sheet_name : str
+        Sheet name of `source`.
+    col : str
+        Column from `sheet_name` to use as codes.
+    attrs : list, optional
+        Columns from `sheet_name` to use as attributes.
+
+    """
+
+    source = pd.read_excel(source, sheet_name=sheet_name)
+    variable = source[[col] + attrs].set_index(col)
+    variable.rename(columns={c: str(c).lower() for c in variable.columns}, inplace=True)
+
+    with open(target, "w") as file:
+        yaml.dump(variable.to_dict(orient="index"), file, default_flow_style=False)


### PR DESCRIPTION
This PR adds a function to turn an xlsx file with a codelist into a yaml file that can be initialized as a `Nomenclature`.