### PR TITLE
Fix validation of dimensionless quantities

### DIFF
--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -12,8 +12,8 @@ def log_error(name, lst):
 
 
 def is_subset(x, y):
-    """Check if x is a subset of y"""
-    return set(to_list(x)).issubset(to_list(y))
+    """Check if x is a subset of y (replacing None by "")"""
+    return set(to_list(x)).issubset([u or "" for u in to_list(y)])
 
 
 def validate(nc, df):

--- a/tests/data/validation_nc/variables/variables.yaml
+++ b/tests/data/validation_nc/variables/variables.yaml
@@ -4,3 +4,6 @@ Primary Energy:
 Primary Energy|Coal:
   definition: Primary energy consumption of coal
   unit: EJ/yr
+Share|Coal:
+  definition: Share of coal in the total primary energy mix
+  unit:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,6 +8,14 @@ def test_validation(simple_nomenclature, simple_df):
     simple_nomenclature.validate(simple_df)
 
 
+def test_validation_dimensionless_unit(simple_nomenclature, simple_df):
+    """Assert that validating against a dimensionless quantity"""
+    mapping = dict(variable={"Primary Energy|Coal": "Share|Coal"}, unit={"EJ/yr": ""})
+    simple_df.rename(mapping, inplace=True)
+
+    simple_nomenclature.validate(simple_df)
+
+
 def test_validation_fails_variable(simple_nomenclature, simple_df):
     """Changing a variable name raises"""
     simple_df.rename(variable={"Primary Energy": "foo"}, inplace=True)


### PR DESCRIPTION
This PR fixes an issue where validation of a dimensionless quantity (i.e., no unit, unit = None or an empty string) failed, reported by @stefanpauliuk in https://github.com/iiasa/irp-internal-workflow/issues/15 (private repo).
