### PR TITLE
Fix error message when unknown items are integers

### DIFF
--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 def log_error(name, lst):
     """Compile an error message and write to log"""
     msg = f"The following {name} are not defined in the nomenclature:"
-    logger.error("\n - ".join([msg] + lst))
+    logger.error("\n - ".join(map(str, [msg] + lst)))
 
 
 def is_subset(x, y):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -38,3 +38,11 @@ def test_validation_fails_region(simple_nomenclature, simple_df):
 
     with pytest.raises(ValueError, match=MATCH_FAIL_VALIDATION):
         simple_nomenclature.validate(simple_df)
+
+
+def test_validation_fails_region_as_int(simple_nomenclature, simple_df):
+    """Using a region name as integer raises the expected error"""
+    simple_df.rename(region={"World": 1}, inplace=True)
+
+    with pytest.raises(ValueError, match=MATCH_FAIL_VALIDATION):
+        simple_nomenclature.validate(simple_df)


### PR DESCRIPTION
This PR fixes an issue when unknown items in the validation are not strings. The issue was reported by @SPDeetman bilaterally.

fyi @stefanpauliuk 