### PR TITLE
Include package-data during setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ url = https://github.com/IAMconsortium/nomenclature
 
 [options]
 packages = nomenclature
+include_package_data = True
 install_requires =
     pyam-iamc >= 0.12  # the pyam package is released on pypi under this name
     openpyxl


### PR DESCRIPTION
This PR fixes the problem that the schema-validation folder is not copied during install.