### PR TITLE
First Version of RegionProcessor

### DIFF
--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -166,7 +166,7 @@ class ModelMappingCollisionError(ValueError):
 
 
 class RegionProcessor(BaseModel):
-    """Reads region mappings from a directory and uses them for region aggregation"""
+    """Region aggregation mappings for scenario processing"""
 
     mappings: Dict[str, RegionAggregationMapping]
 

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -153,7 +153,7 @@ class RegionAggregationMapping(BaseModel):
 
 
 class ModelMappingCollisionError(ValueError):
-    template = "Model {model} is defined twice in {files}"
+    template = "Multiple region aggregation mappings for model {model} in {files}"
 
     def __init__(
         self, mapping1: RegionAggregationMapping, mapping2: RegionAggregationMapping

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -172,9 +172,9 @@ class RegionProcessor(BaseModel):
 
     @classmethod
     @validate_arguments
-    def from_directory(cls, mappingdir: DirectoryPath):
+    def from_directory(cls, path: DirectoryPath):
         mapping_dict: Dict[str, RegionAggregationMapping] = {}
-        for file in mappingdir.glob("**/*.yaml"):
+        for file in path.glob("**/*.yaml"):
             mapping = RegionAggregationMapping.create_from_region_mapping(file)
             if mapping.model not in mapping_dict:
                 mapping_dict[mapping.model] = mapping

--- a/tests/data/regionprocessor_duplicate/mapping_1.yaml
+++ b/tests/data/regionprocessor_duplicate/mapping_1.yaml
@@ -1,0 +1,6 @@
+model: model_a
+native_regions:
+  - region_a
+common_regions:
+  - common_region_1:
+    - region_a

--- a/tests/data/regionprocessor_duplicate/mapping_2.yaml
+++ b/tests/data/regionprocessor_duplicate/mapping_2.yaml
@@ -1,0 +1,6 @@
+model: model_a
+native_regions:
+  - region_a
+common_regions:
+  - common_region_1:
+    - region_a

--- a/tests/data/regionprocessor_working/mapping_1.yaml
+++ b/tests/data/regionprocessor_working/mapping_1.yaml
@@ -1,0 +1,6 @@
+model: model_a
+native_regions:
+  - region_a
+common_regions:
+  - common_region_1:
+    - region_a

--- a/tests/data/regionprocessor_working/mapping_2.yaml
+++ b/tests/data/regionprocessor_working/mapping_2.yaml
@@ -1,0 +1,6 @@
+model: model_b
+native_regions:
+  - region_a
+common_regions:
+  - common_region_1:
+    - region_a

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -116,15 +116,13 @@ def test_region_processor_wrong_args():
     # Test if pydantic correctly type checks the input of RegionProcessor.from_directory
 
     # Test with an integer
-    with pytest.raises(
-        pydantic.ValidationError, match=".*mappingdir\n.*not a valid path.*"
-    ):
+    with pytest.raises(pydantic.ValidationError, match=".*path\n.*not a valid path.*"):
         RegionProcessor.from_directory(123)
 
     # Test with a file, a path pointing to a directory is required
     with pytest.raises(
         pydantic.ValidationError,
-        match=".*mappingdir\n.*does not point to a directory.*",
+        match=".*path\n.*does not point to a directory.*",
     ):
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml"

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -1,18 +1,18 @@
 import jsonschema
 import pydantic
 import pytest
-from nomenclature.region_mapping_models import RegionAggregationMapping
+from nomenclature.region_mapping_models import RegionAggregationMapping, RegionProcessor
 
 from conftest import TEST_DATA_DIR
 
-test_folder = TEST_DATA_DIR / "region_aggregation"
+test_folder_region_mapping = TEST_DATA_DIR / "region_aggregation"
 
 
 def test_mapping():
     mapping_file = "working_mapping.yaml"
     # Test that the file is read and represented correctly
     obs = RegionAggregationMapping.create_from_region_mapping(
-        test_folder / mapping_file
+        test_folder_region_mapping / mapping_file
     )
     exp = {
         "model": "model_a",
@@ -90,6 +90,16 @@ def test_model_only_mapping():
         "common_regions": None,
     }
     obs = RegionAggregationMapping.create_from_region_mapping(
-        test_folder / "working_mapping_model_only.yaml"
+        test_folder_region_mapping / "working_mapping_model_only.yaml"
     )
     assert exp == obs.dict()
+
+
+def test_working_region_processor():
+    rp = RegionProcessor(TEST_DATA_DIR / "regionprocessor_working")
+    assert {"model_a", "model_b"} == set(rp.keys())
+
+
+def test_duplicate_region_processor():
+    with pytest.raises(KeyError, match="model_a"):
+        RegionProcessor(TEST_DATA_DIR / "regionprocessor_duplicate")


### PR DESCRIPTION
closes #27. 

This is a first implementation of the required `RegionProcessor` class. Implementation is heavily inspired by the `CodeList` class.
For now the only thing that is implemented is checking for region mappings which are defined twice.
There are two unit tests which check for normal working state and for the failure condition of a double model mapping.
One improvement which should still be introduced is that when errors are reported we are currently not informed which mapping files are involved. Adding this should greatly improve the user experience. 
This should probably also be added to the already existing `RegionAggregationMapping`.

EDIT:
On second thought, adding file names to the errors in `RegionAggregationMapping` probably deserves its own issue & PR. I'll open that.