### PR TITLE
Feature/error enhancement region aggregation

### DIFF
--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -26,7 +26,7 @@ class CommonRegion(BaseModel):
 
 class RegionAggregationMapping(BaseModel):
     model: str
-    mapping_file: FilePath
+    file: FilePath
     native_regions: Optional[List[NativeRegion]]
     common_regions: Optional[List[CommonRegion]]
 
@@ -66,7 +66,7 @@ class RegionAggregationMapping(BaseModel):
         if overlap:
             raise ValueError(
                 "Conflict between (renamed) native regions and aggregation mapping"
-                f" to common regions: {overlap} in {values['mapping_file']}"
+                f" to common regions: {overlap} in {values['file']}"
             )
         return values
 
@@ -86,7 +86,7 @@ class RegionAggregationMapping(BaseModel):
             raise ValidationError(f"{e.message} in {file}")
 
         # Add the file name to mapping_input
-        mapping_input["mapping_file"] = file
+        mapping_input["file"] = file
 
         # Reformat the "native_regions"
         if "native_regions" in mapping_input:

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -38,7 +38,8 @@ class RegionAggregationMapping(BaseModel):
         ]
         if duplicates:
             raise ValueError(
-                f"Two or more native regions share the same name: {duplicates} in {values['mapping_file']}"
+                f"Two or more native regions share the same name: {duplicates} in "
+                f"{values['file']}"
             )
         return v
 
@@ -48,7 +49,8 @@ class RegionAggregationMapping(BaseModel):
         duplicates = [item for item, count in Counter(names).items() if count > 1]
         if duplicates:
             raise ValueError(
-                f"Duplicated aggregation mapping to common regions: {duplicates} in {values['mapping_file']}"
+                f"Duplicated aggregation mapping to common regions: {duplicates} in "
+                f"{values['file']}"
             )
         return v
 

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -18,8 +18,9 @@ original__str__ = copy.deepcopy(pydantic.error_wrappers.ValidationError.__str__)
 
 # Define a new __str__ method which adds file information in case it is present.
 # Otherwise the original __str__ method is used.
-def new__str__(self):
 
+
+def new__str__(self):
     """Change __str__ from pydantic ValidationError to include the file name if
     present"""
     if "ctx" in self.errors()[0] and "file" in self.errors()[0]["ctx"]:

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -1,6 +1,5 @@
 import copy
 from collections import Counter
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
@@ -20,6 +19,7 @@ original__str__ = copy.deepcopy(pydantic.error_wrappers.ValidationError.__str__)
 # Define a new __str__ method which adds file information in case it is present.
 # Otherwise the original __str__ method is used.
 def new__str__(self):
+
     """Change __str__ from pydantic ValidationError to include the file name if
     present"""
     if "ctx" in self.errors()[0] and "file" in self.errors()[0]["ctx"]:

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -39,7 +39,7 @@ class RegionAggregationMapping(BaseModel):
         if duplicates:
             raise ValueError(
                 f"Two or more native regions share the same name: {duplicates} in "
-                f"{values['file']}"
+                f"{values['file'].relative_to(Path.cwd())}"
             )
         return v
 
@@ -50,7 +50,7 @@ class RegionAggregationMapping(BaseModel):
         if duplicates:
             raise ValueError(
                 f"Duplicated aggregation mapping to common regions: {duplicates} in "
-                f"{values['file']}"
+                f"{values['file'].relative_to(Path.cwd())}"
             )
         return v
 
@@ -68,7 +68,8 @@ class RegionAggregationMapping(BaseModel):
         if overlap:
             raise ValueError(
                 "Conflict between (renamed) native regions and aggregation mapping"
-                f" to common regions: {overlap} in {values['file']}"
+                f" to common regions: {overlap} in "
+                f"{values['file'].relative_to(Path.cwd())}"
             )
         return values
 

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -150,10 +150,3 @@ class RegionAggregationMapping(BaseModel):
                 )
             mapping_input["common_regions"] = common_region_list
         return cls(**mapping_input)
-
-
-# if __name__ == "__main__":
-#     RegionAggregationMapping.create_from_region_mapping(
-#         Path(__file__).parents[1]
-#         / "tests/data/region_aggregation/illegal_mapping_duplicate_native.yaml"
-#     )

--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -1,13 +1,30 @@
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Set, Tuple
 from collections import Counter
 from pydantic.types import FilePath
+from collections.abc import Sequence
 
 import yaml
 from jsonschema import validate, ValidationError
 from pydantic import BaseModel, validator, root_validator
 
 here = Path(__file__).parent.absolute()
+
+
+Sequence = Union[List[str], Tuple[str], Set[str]]
+
+
+class NameCollisionError(ValueError):
+    template = 'Name collision in {location} for "{duplicates}" in {rel_file}'
+
+    def __init__(self, location: str, duplicates: Sequence, file: Path) -> None:
+        super().__init__(
+            self.template.format(
+                location=location,
+                duplicates=duplicates,
+                rel_file=file.relative_to(Path.cwd()),
+            )
+        )
 
 
 class NativeRegion(BaseModel):
@@ -37,10 +54,7 @@ class RegionAggregationMapping(BaseModel):
             item for item, count in Counter(target_names).items() if count > 1
         ]
         if duplicates:
-            raise ValueError(
-                f"Two or more native regions share the same name: {duplicates} in "
-                f"{values['file'].relative_to(Path.cwd())}"
-            )
+            raise NameCollisionError("native regions", duplicates, values["file"])
         return v
 
     @validator("common_regions")
@@ -48,10 +62,7 @@ class RegionAggregationMapping(BaseModel):
         names = [cr.name for cr in v]
         duplicates = [item for item, count in Counter(names).items() if count > 1]
         if duplicates:
-            raise ValueError(
-                f"Duplicated aggregation mapping to common regions: {duplicates} in "
-                f"{values['file'].relative_to(Path.cwd())}"
-            )
+            raise NameCollisionError("common regions", duplicates, values["file"])
         return v
 
     @root_validator()
@@ -66,10 +77,8 @@ class RegionAggregationMapping(BaseModel):
         common_region_names = {cr.name for cr in values["common_regions"]}
         overlap = list(native_region_names & common_region_names)
         if overlap:
-            raise ValueError(
-                "Conflict between (renamed) native regions and aggregation mapping"
-                f" to common regions: {overlap} in "
-                f"{values['file'].relative_to(Path.cwd())}"
+            raise NameCollisionError(
+                "common and native regions", overlap, values["file"]
             )
         return values
 
@@ -116,3 +125,10 @@ class RegionAggregationMapping(BaseModel):
                 )
             mapping_input["common_regions"] = common_region_list
         return cls(**mapping_input)
+
+
+# if __name__ == "__main__":
+#     RegionAggregationMapping.create_from_region_mapping(
+#         Path(__file__).parents[1]
+#         / "tests/data/region_aggregation/illegal_mapping_duplicate_native.yaml"
+#     )

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -75,7 +75,7 @@ def test_mapping():
 def test_illegal_mappings(file, error_type, error_msg_pattern):
     # This is to test a few different failure conditions
 
-    with pytest.raises(error_type, match=error_msg_pattern):
+    with pytest.raises(error_type, match=f"{error_msg_pattern}{file}.*"):
         RegionAggregationMapping.create_from_region_mapping(test_folder / file)
 
 

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -15,6 +15,7 @@ def test_mapping():
     )
     exp = {
         "model": "model_a",
+        "mapping_file": test_folder / mapping_file,
         "native_regions": [
             {"name": "region_a", "rename": "alternative_name_a"},
             {"name": "region_b", "rename": "alternative_name_b"},
@@ -83,6 +84,7 @@ def test_model_only_mapping():
     # test that a region mapping runs also with only a model
     exp = {
         "model": "model_a",
+        "mapping_file": test_folder / "working_mapping_model_only.yaml",
         "native_regions": None,
         "common_regions": None,
     }

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -15,7 +15,7 @@ def test_mapping():
     )
     exp = {
         "model": "model_a",
-        "mapping_file": test_folder / mapping_file,
+        "file": test_folder / mapping_file,
         "native_regions": [
             {"name": "region_a", "rename": "alternative_name_a"},
             {"name": "region_b", "rename": "alternative_name_b"},
@@ -84,7 +84,7 @@ def test_model_only_mapping():
     # test that a region mapping runs also with only a model
     exp = {
         "model": "model_a",
-        "mapping_file": test_folder / "working_mapping_model_only.yaml",
+        "file": test_folder / "working_mapping_model_only.yaml",
         "native_regions": None,
         "common_regions": None,
     }

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -1,7 +1,6 @@
 import jsonschema
 import pydantic
 import pytest
-from pathlib import Path
 from nomenclature.region_mapping_models import RegionAggregationMapping
 
 from conftest import TEST_DATA_DIR

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -54,22 +54,22 @@ def test_mapping():
         (
             "illegal_mapping_conflict_regions.yaml",
             ValueError,
-            r".*Conflict between \(renamed\).*common_region_1.*",
+            ".*Name collision.*common and native regions.*common_region_1.*",
         ),
         (
             "illegal_mapping_duplicate_native.yaml",
             ValueError,
-            ".*Two or more.*alternative_name_a.*",
+            ".*Name collision.*native regions.*alternative_name_a.*",
         ),
         (
             "illegal_mapping_duplicate_native_rename.yaml",
             ValueError,
-            ".*Two or more.*alternative_name_a.*",
+            ".*Name collision.*native regions.*alternative_name_a.*",
         ),
         (
             "illegal_mapping_duplicate_common.yaml",
             ValueError,
-            ".*common regions.*common_region_1.*",
+            "Name collision.*common regions.*common_region_1.*",
         ),
     ],
 )

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -56,7 +56,7 @@ def test_mapping():
         (
             "illegal_mapping_conflict_regions.yaml",
             pydantic.ValidationError,
-            r".*Conflict between \(renamed\).*common_region_1.*",
+            ".*Name collision in native and common regions.*common_region_1.*",
         ),
         (
             "illegal_mapping_duplicate_native.yaml",
@@ -71,7 +71,7 @@ def test_mapping():
         (
             "illegal_mapping_duplicate_common.yaml",
             pydantic.ValidationError,
-            ".*common regions.*common_region_1.*",
+            ".*Name collision in common regions.*common_region_1.*",
         ),
     ],
 )


### PR DESCRIPTION
closes #33

### Changes
* Added a property `file` to `RegionAggregationMapping`. The type of `file` is [`pydantic.types.FilePath`](https://pydantic-docs.helpmanual.io/usage/types/#pydantic-types) which conveniently validates that `file` points to a file. 
* Added this file information to validation errors inside `RegionAggregationMapping` for better error reporting.

As #32 should build on this, my preference would be to merge this first.

### Open Points

Right now the error specify the entire file path, maybe it would be better to limit it to the file name plus maybe one or two parent folders. Instead of `/home/user/.../mappings/some_mapping_file.yaml` we would get `mappings/some_mapping_file.yaml` or maybe only `some_mapping_file.yaml`. What do you think @danielhuppmann?
It might even be safety relevant as I'm not sure we want to give the entire file path of our server side folder structure in case this is running as part of a scenario explorer instance. 