### PR TITLE
Check allowed regions

### DIFF
--- a/tests/data/regionprocessor_not_defined/mapping_1.yaml
+++ b/tests/data/regionprocessor_not_defined/mapping_1.yaml
@@ -1,0 +1,3 @@
+model: model_a
+native_regions:
+  - region_a

--- a/tests/data/regionprocessor_not_defined/mapping_2.yaml
+++ b/tests/data/regionprocessor_not_defined/mapping_2.yaml
@@ -1,0 +1,3 @@
+model: model_b
+native_regions:
+  - region_a

--- a/tests/data/regionprocessor_working/mapping_1.yaml
+++ b/tests/data/regionprocessor_working/mapping_1.yaml
@@ -1,6 +1,3 @@
 model: model_a
 native_regions:
-  - region_a
-common_regions:
-  - common_region_1:
-    - region_a
+  - World

--- a/tests/data/regionprocessor_working/mapping_2.yaml
+++ b/tests/data/regionprocessor_working/mapping_2.yaml
@@ -1,6 +1,5 @@
 model: model_b
-native_regions:
-  - region_a
 common_regions:
-  - common_region_1:
+  - World:
     - region_a
+    - region_b

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -7,7 +7,7 @@ from nomenclature.region_mapping_models import (
     ModelMappingCollisionError,
 )
 
-from conftest import TEST_DATA_DIR, simple_nomenclature
+from conftest import TEST_DATA_DIR
 
 TEST_FOLDER_REGION_MAPPING = TEST_DATA_DIR / "region_aggregation"
 

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -101,22 +101,64 @@ def test_model_only_mapping():
     assert exp == obs.dict()
 
 
-def test_working_region_processor(simple_nomenclature):
-    rp = RegionProcessor.from_directory(
+def test_region_processor_working(simple_nomenclature):
+
+    obs = RegionProcessor.from_directory(
         TEST_DATA_DIR / "regionprocessor_working", simple_nomenclature
     )
-    assert {"model_a", "model_b"} == set(rp.mappings.keys())
+    exp_data = [
+        {
+            "model": "model_a",
+            "file": TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml",
+            "native_regions": [
+                {"name": "World", "rename": None},
+            ],
+            "common_regions": None,
+        },
+        {
+            "model": "model_b",
+            "file": TEST_DATA_DIR / "regionprocessor_working/mapping_2.yaml",
+            "native_regions": None,
+            "common_regions": [
+                {
+                    "name": "World",
+                    "constituent_regions": [
+                        {"name": "region_a", "rename": None},
+                        {"name": "region_b", "rename": None},
+                    ],
+                }
+            ],
+        },
+    ]
+    exp_models = {value["model"] for value in exp_data}
+    exp_dict = {value["model"]: value for value in exp_data}
+
+    assert exp_models == set(obs.mappings.keys())
+    assert all(exp_dict[m] == obs.mappings[m].dict() for m in exp_models)
 
 
-def test_duplicate_region_processor(simple_nomenclature):
-    error = ".*model_a.*mapping_1.yaml.*mapping_2.yaml"
-    with pytest.raises(ModelMappingCollisionError, match=error):
+def test_region_processor_not_defined(simple_nomenclature):
+    # Test a RegionProcessor with regions that are not defined in the data structure
+    # definition
+    error_msg = (
+        "model_b\n.*region_a.*mapping_2.yaml.*value_error.region_not_defined."
+        "*\n.*model_a\n.*region_a.*mapping_1.yaml.*value_error.region_not_defined"
+    )
+    with pytest.raises(pydantic.ValidationError, match=error_msg):
+        RegionProcessor.from_directory(
+            TEST_DATA_DIR / "regionprocessor_not_defined", simple_nomenclature
+        )
+
+
+def test_region_processor_duplicate_model_mapping(simple_nomenclature):
+    error_msg = ".*model_a.*mapping_1.yaml.*mapping_2.yaml"
+    with pytest.raises(ModelMappingCollisionError, match=error_msg):
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_duplicate", simple_nomenclature
         )
 
 
-def test_region_processor_wrong_args():
+def test_region_processor_wrong_args(simple_nomenclature):
     # Test if pydantic correctly type checks the input of RegionProcessor.from_directory
 
     # Test with an integer
@@ -129,5 +171,6 @@ def test_region_processor_wrong_args():
         match=".*path\n.*does not point to a directory.*",
     ):
         RegionProcessor.from_directory(
-            TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml"
+            TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml",
+            simple_nomenclature,
         )

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -108,10 +108,12 @@ def test_working_region_processor(simple_nomenclature):
     assert {"model_a", "model_b"} == set(rp.mappings.keys())
 
 
-def test_duplicate_region_processor():
+def test_duplicate_region_processor(simple_nomenclature):
     error = ".*model_a.*mapping_1.yaml.*mapping_2.yaml"
     with pytest.raises(ModelMappingCollisionError, match=error):
-        RegionProcessor.from_directory(TEST_DATA_DIR / "regionprocessor_duplicate")
+        RegionProcessor.from_directory(
+            TEST_DATA_DIR / "regionprocessor_duplicate", simple_nomenclature
+        )
 
 
 def test_region_processor_wrong_args():

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -7,7 +7,7 @@ from nomenclature.region_mapping_models import (
     ModelMappingCollisionError,
 )
 
-from conftest import TEST_DATA_DIR
+from conftest import TEST_DATA_DIR, simple_nomenclature
 
 TEST_FOLDER_REGION_MAPPING = TEST_DATA_DIR / "region_aggregation"
 
@@ -101,8 +101,10 @@ def test_model_only_mapping():
     assert exp == obs.dict()
 
 
-def test_working_region_processor():
-    rp = RegionProcessor.from_directory(TEST_DATA_DIR / "regionprocessor_working")
+def test_working_region_processor(simple_nomenclature):
+    rp = RegionProcessor.from_directory(
+        TEST_DATA_DIR / "regionprocessor_working", simple_nomenclature
+    )
     assert {"model_a", "model_b"} == set(rp.mappings.keys())
 
 


### PR DESCRIPTION
closes #26 

For now a draft PR as I ran into an issue with the modified error messages while adding the validation for allowed regions using a `DataStructureDefinition` instance.
The issue has to do with how pydantic handles errors, in particular when multiple error occur during evaluation. Pydantic collects them all and wraps them in one `pydantic.ValidationError` at the end. The example below illustrates this:

```python
pydantic.error_wrappers.ValidationError: 2 validation errors for RegionProcessor in /tests/data/regionprocessor_working/mapping_2.yaml
mappings -> model_b
  Region(s) ['region_a', 'common_region_1'] in /tests/data/regionprocessor_working/mapping_2.yaml not defined (type=value_error.regionnotdefined; file=/tests/data/regionprocessor_working/mapping_2.yaml)
mappings -> model_a
  Region(s) ['region_a', 'common_region_1'] in /tests/data/regionprocessor_working/mapping_1.yaml not defined (type=value_error.regionnotdefined; file=/tests/data/regionprocessor_working/mapping_1.yaml)
```

The problem is now that when I previously overwrote the `__str__` function of `pydantic.ValidationError` it was under the assumption that one `ValidationError` would only ever correspond to one single mapping source file. Now we have potentially a lot of mapping files as we run through all mappings. I could just list them in the first line but I think that would make it not very clean.
So I would vote to pivot back to the original way pydantic formats errors and just have the file in the line with the error as it is also the case in the above example.
What do you think @danielhuppmann?

