### PR TITLE
Add minimum version requirement for click

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/IAMconsortium/nomenclature
 packages = nomenclature
 include_package_data = True
 install_requires =
-    click
+    click >= 8
     pyam-iamc >= 0.12  # the pyam package is released on pypi under this name
     openpyxl
     setuptools >= 41


### PR DESCRIPTION
Since click 7.1.2 broke two unit tests on my machine I have added a minimum version requirement `click >= 8`.