### PR TITLE
Add test_valid_mappings to CLI 'validate-project'

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -3,9 +3,9 @@ import logging
 from nomenclature.codes import CodeList  # noqa
 from nomenclature.core import DataStructureDefinition, create_yaml_from_xlsx  # noqa
 from nomenclature.testing import assert_valid_yaml  # noqa
-from nomenclature.region_mapping_models import (
-    RegionProcessor,  # noqa
-    RegionAggregationMapping,  # noqa
+from nomenclature.region_mapping_models import (  # noqa
+    RegionProcessor,
+    RegionAggregationMapping,
 )
 
 

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -3,7 +3,10 @@ import logging
 from nomenclature.codes import CodeList  # noqa
 from nomenclature.core import DataStructureDefinition, create_yaml_from_xlsx  # noqa
 from nomenclature.testing import assert_valid_yaml  # noqa
-from nomenclature.region_mapping_models import RegionProcessor, RegionAggregationMapping
+from nomenclature.region_mapping_models import (
+    RegionProcessor,
+    RegionAggregationMapping,
+)  # noqa
 
 
 # set up logging

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -4,9 +4,9 @@ from nomenclature.codes import CodeList  # noqa
 from nomenclature.core import DataStructureDefinition, create_yaml_from_xlsx  # noqa
 from nomenclature.testing import assert_valid_yaml  # noqa
 from nomenclature.region_mapping_models import (
-    RegionProcessor,
-    RegionAggregationMapping,
-)  # noqa
+    RegionProcessor,  # noqa
+    RegionAggregationMapping,  # noqa
+)
 
 
 # set up logging

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -3,6 +3,7 @@ import logging
 from nomenclature.codes import CodeList  # noqa
 from nomenclature.core import DataStructureDefinition, create_yaml_from_xlsx  # noqa
 from nomenclature.testing import assert_valid_yaml  # noqa
+from nomenclature.region_mapping_models import RegionProcessor, RegionAggregationMapping
 
 
 # set up logging

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -22,6 +22,7 @@ def cli_valid_yaml(path: Path):
 def cli_valid_project(path: Path):
     assert_valid_yaml(path)
     assert_valid_structure(path)
+    assert_valid_mappings(path)
 
 
 def assert_valid_yaml(path: Path):
@@ -48,6 +49,13 @@ def assert_valid_structure(path: Path):
     """Check that "definitions" folder in `path` exists and
     can be initialized without errors"""
     nomenclature.DataStructureDefinition(path / "definitions")
+
+
+def assert_valid_mappings(path: Path):
+    """Check that if a "mappings" folder exists it only contains valid mappings"""
+    if (path / "mappings").is_dir():
+        definition = nomenclature.DataStructureDefinition(path / "definitions")
+        nomenclature.RegionProcessor.from_directory(path / "mappings", definition)
 
 
 # Todo: add function which runs `DataStrutureDefinition(path).validate(scenario)`

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -22,7 +22,6 @@ def cli_valid_yaml(path: Path):
 def cli_valid_project(path: Path):
     assert_valid_yaml(path)
     assert_valid_structure(path)
-    assert_valid_mappings(path)
 
 
 def assert_valid_yaml(path: Path):
@@ -48,13 +47,8 @@ def assert_valid_yaml(path: Path):
 def assert_valid_structure(path: Path):
     """Check that "definitions" folder in `path` exists and
     can be initialized without errors"""
-    nomenclature.DataStructureDefinition(path / "definitions")
-
-
-def assert_valid_mappings(path: Path):
-    """Check that if a "mappings" folder exists it only contains valid mappings"""
+    definition = nomenclature.DataStructureDefinition(path / "definitions")
     if (path / "mappings").is_dir():
-        definition = nomenclature.DataStructureDefinition(path / "definitions")
         nomenclature.RegionProcessor.from_directory(path / "mappings", definition)
 
 

--- a/tests/data/structure_validation/definitions/foo.yaml
+++ b/tests/data/structure_validation/definitions/foo.yaml
@@ -1,3 +1,0 @@
-- Some Variable:
-    definition: Some basic variable
-    unit:  # testing that importing an empty unit (ie dimensionless variable) works

--- a/tests/data/structure_validation/definitions/regions/regions.yaml
+++ b/tests/data/structure_validation/definitions/regions/regions.yaml
@@ -1,0 +1,2 @@
+- common:
+  - World

--- a/tests/data/structure_validation/definitions/variables/variables.yaml
+++ b/tests/data/structure_validation/definitions/variables/variables.yaml
@@ -1,0 +1,3 @@
+- Primary Energy:
+    definition: Total primary energy consumption
+    unit: EJ/yr

--- a/tests/data/structure_validation/mappings/mapping_1.yaml
+++ b/tests/data/structure_validation/mappings/mapping_1.yaml
@@ -1,0 +1,3 @@
+model: model_a
+native_regions:
+  - World

--- a/tests/data/structure_validation/mappings/mapping_2.yaml
+++ b/tests/data/structure_validation/mappings/mapping_2.yaml
@@ -1,0 +1,5 @@
+model: model_b
+common_regions:
+  - World:
+    - region_a
+    - region_b

--- a/tests/data/structure_validation_fails/definitions/regions/regions.yaml
+++ b/tests/data/structure_validation_fails/definitions/regions/regions.yaml
@@ -1,0 +1,2 @@
+- common:
+  - World

--- a/tests/data/structure_validation_fails/definitions/variables/variables.yaml
+++ b/tests/data/structure_validation_fails/definitions/variables/variables.yaml
@@ -1,0 +1,3 @@
+- Primary Energy:
+    definition: Total primary energy consumption
+    unit: EJ/yr

--- a/tests/data/structure_validation_fails/mappings/mapping_1.yaml
+++ b/tests/data/structure_validation_fails/mappings/mapping_1.yaml
@@ -1,0 +1,3 @@
+model: model_a
+native_regions:
+  - World

--- a/tests/data/structure_validation_fails/mappings/mapping_2.yaml
+++ b/tests/data/structure_validation_fails/mappings/mapping_2.yaml
@@ -1,0 +1,7 @@
+model: model_b
+native_regions:
+  - region_a
+common_regions:
+  - World:
+    - region_a
+    - region_b

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,7 +44,8 @@ def test_cli_valid_project_path():
 
 
 def test_cli_valid_project():
-    """Check that CLI runs through with existing "definitions" and "mappings" directory"""
+    """Check that CLI runs through with existing "definitions" and "mappings"
+    directory"""
     result_valid = runner.invoke(
         cli, ["validate-project", str(TEST_DATA_DIR / "structure_validation")]
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 from nomenclature.testing import cli, assert_valid_yaml, assert_valid_structure
 import pytest
+import pydantic
 
 from conftest import TEST_DATA_DIR
 
@@ -43,11 +44,21 @@ def test_cli_valid_project_path():
 
 
 def test_cli_valid_project():
-    """Check that CLI runs through with existing "definitions" directory"""
+    """Check that CLI runs through with existing "definitions" and "mappings" directory"""
     result_valid = runner.invoke(
         cli, ["validate-project", str(TEST_DATA_DIR / "structure_validation")]
     )
     assert result_valid.exit_code == 0
+
+
+def test_cli_invalid_region():
+    """Test that errors are correctly propagated"""
+    obs = runner.invoke(
+        cli, ["validate-project", str(TEST_DATA_DIR / "structure_validation_fails")]
+    )
+    assert obs.exit_code == 1
+    assert isinstance(obs.exception, pydantic.ValidationError)
+    assert "region_a" in obs.exception.errors()[0]["msg"]
 
 
 def test_cli_valid_project_fails():


### PR DESCRIPTION
Edited after suggestion from @danielhuppmann:

~~This PR adds a function `assert_valid_mappings` to `nomenclature/testing.py`.~~
~~This function is called as the last step in `cli_valid_project`.~~

This PR adds checking the mappings to `assert_valid_structure`.

Added two unit tests to test the new feature, one to run, one to fail.