### PR TITLE
Change references to nomenclature to DataStructureDefinition

### DIFF
--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -38,7 +38,8 @@ class DataStructureDefinition:
         Parameters
         ----------
         df : IamDataFrame
-            An IamDataFrame to be validated against the codelists of this nomenclature.
+            An IamDataFrame to be validated against the codelists of this
+            DataStructureDefinition.
 
         Returns
         -------

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def log_error(name, lst):
     """Compile an error message and write to log"""
-    msg = f"The following {name} are not defined in the nomenclature:"
+    msg = f"The following {name} are not defined in the DataStructureDefinition:"
     logger.error("\n - ".join(map(str, [msg] + lst)))
 
 
@@ -16,8 +16,8 @@ def is_subset(x, y):
     return set(to_list(x)).issubset([u or "" for u in to_list(y)])
 
 
-def validate(nc, df):
-    """Validation of an IamDataFrame against codelists of a Nomenclature"""
+def validate(dsd, df):
+    """Validation of an IamDataFrame against codelists of a DataStructureDefinition"""
 
     if not isinstance(df, IamDataFrame):
         df = IamDataFrame(df)
@@ -27,17 +27,17 @@ def validate(nc, df):
     # combined validation of variables and units
     invalid_vars, invalid_units = [], []
     for variable, unit in df.unit_mapping.items():
-        if variable not in nc.variable:
+        if variable not in dsd.variable:
             invalid_vars.append(variable)
         else:
-            nc_unit = nc.variable[variable]["unit"]
-            # fast-pass for unique units in df and the nomenclature
-            if nc_unit == unit:
+            dsd_unit = dsd.variable[variable]["unit"]
+            # fast-pass for unique units in df and the DataStructureDefinition
+            if dsd_unit == unit:
                 continue
             # full-fledged subset validation
-            if is_subset(unit, nc_unit):
+            if is_subset(unit, dsd_unit):
                 continue
-            invalid_units.append((variable, unit, nc_unit))
+            invalid_units.append((variable, unit, dsd_unit))
 
     if invalid_vars:
         log_error("variables", invalid_vars)
@@ -50,7 +50,7 @@ def validate(nc, df):
 
     # loop over other dimensions for validation
     cols = [
-        (df.region, nc.region, "regions"),
+        (df.region, dsd.region, "regions"),
     ]
 
     for values, codelist, name in cols:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ TEST_DF = pd.DataFrame(
 
 
 @pytest.fixture(scope="session")
-def simple_nomenclature():
+def simple_definition():
     yield DataStructureDefinition(TEST_DATA_DIR / "validation_nc")
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,17 +6,18 @@ from conftest import TEST_DATA_DIR
 
 
 def test_nonexisting_path_raises():
-    """Check that initializing a Nomenclature with a non-existing path raises"""
+    """Check that initializing a DataStructureDefinition with a non-existing path
+    raises"""
     match = "Definitions directory not found: foo"
     with pytest.raises(NotADirectoryError, match=match):
         DataStructureDefinition("foo")
 
 
-def test_to_excel(simple_nomenclature, tmpdir):
-    """Check writing a nomenclature to file"""
+def test_to_excel(simple_definition, tmpdir):
+    """Check writing a DataStructureDefinition to file"""
     file = tmpdir / "testing_export.xlsx"
 
-    simple_nomenclature.to_excel(file)
+    simple_definition.to_excel(file)
 
     obs = pd.read_excel(file)
     exp = pd.read_excel(TEST_DATA_DIR / "validation_nc.xlsx")

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -92,10 +92,10 @@ def test_illegal_mappings(file, error_type, error_msg_pattern):
         )
 
 
-def test_region_processor_working(simple_nomenclature):
+def test_region_processor_working(simple_definition):
 
     obs = RegionProcessor.from_directory(
-        TEST_DATA_DIR / "regionprocessor_working", simple_nomenclature
+        TEST_DATA_DIR / "regionprocessor_working", simple_definition
     )
     exp_data = [
         {
@@ -125,7 +125,7 @@ def test_region_processor_working(simple_nomenclature):
     assert all(exp_dict[m] == obs.mappings[m].dict() for m in exp_models)
 
 
-def test_region_processor_not_defined(simple_nomenclature):
+def test_region_processor_not_defined(simple_definition):
     # Test a RegionProcessor with regions that are not defined in the data structure
     # definition
     error_msg = (
@@ -134,19 +134,19 @@ def test_region_processor_not_defined(simple_nomenclature):
     )
     with pytest.raises(pydantic.ValidationError, match=error_msg):
         RegionProcessor.from_directory(
-            TEST_DATA_DIR / "regionprocessor_not_defined", simple_nomenclature
+            TEST_DATA_DIR / "regionprocessor_not_defined", simple_definition
         )
 
 
-def test_region_processor_duplicate_model_mapping(simple_nomenclature):
+def test_region_processor_duplicate_model_mapping(simple_definition):
     error_msg = ".*model_a.*mapping_1.yaml.*mapping_2.yaml"
     with pytest.raises(ModelMappingCollisionError, match=error_msg):
         RegionProcessor.from_directory(
-            TEST_DATA_DIR / "regionprocessor_duplicate", simple_nomenclature
+            TEST_DATA_DIR / "regionprocessor_duplicate", simple_definition
         )
 
 
-def test_region_processor_wrong_args(simple_nomenclature):
+def test_region_processor_wrong_args(simple_definition):
     # Test if pydantic correctly type checks the input of RegionProcessor.from_directory
 
     # Test with an integer
@@ -160,7 +160,7 @@ def test_region_processor_wrong_args(simple_nomenclature):
     ):
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml",
-            simple_nomenclature,
+            simple_definition,
         )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,46 +3,46 @@ import pytest
 MATCH_FAIL_VALIDATION = "The validation failed. Please check the log for details."
 
 
-def test_validation(simple_nomenclature, simple_df):
+def test_validation(simple_definition, simple_df):
     """A simple validation passes as expected"""
-    simple_nomenclature.validate(simple_df)
+    simple_definition.validate(simple_df)
 
 
-def test_validation_dimensionless_unit(simple_nomenclature, simple_df):
+def test_validation_dimensionless_unit(simple_definition, simple_df):
     """Assert that validating against a dimensionless quantity"""
     mapping = dict(variable={"Primary Energy|Coal": "Share|Coal"}, unit={"EJ/yr": ""})
     simple_df.rename(mapping, inplace=True)
 
-    simple_nomenclature.validate(simple_df)
+    simple_definition.validate(simple_df)
 
 
-def test_validation_fails_variable(simple_nomenclature, simple_df):
+def test_validation_fails_variable(simple_definition, simple_df):
     """Changing a variable name raises"""
     simple_df.rename(variable={"Primary Energy": "foo"}, inplace=True)
 
     with pytest.raises(ValueError, match=MATCH_FAIL_VALIDATION):
-        simple_nomenclature.validate(simple_df)
+        simple_definition.validate(simple_df)
 
 
-def test_validation_fails_unit(simple_nomenclature, simple_df):
+def test_validation_fails_unit(simple_definition, simple_df):
     """Changing a unit raises"""
     simple_df.rename(unit={"EJ/yr": "GWh/yr"}, inplace=True)
 
     with pytest.raises(ValueError, match=MATCH_FAIL_VALIDATION):
-        simple_nomenclature.validate(simple_df)
+        simple_definition.validate(simple_df)
 
 
-def test_validation_fails_region(simple_nomenclature, simple_df):
+def test_validation_fails_region(simple_definition, simple_df):
     """Changing a region name raises"""
     simple_df.rename(region={"World": "foo"}, inplace=True)
 
     with pytest.raises(ValueError, match=MATCH_FAIL_VALIDATION):
-        simple_nomenclature.validate(simple_df)
+        simple_definition.validate(simple_df)
 
 
-def test_validation_fails_region_as_int(simple_nomenclature, simple_df):
+def test_validation_fails_region_as_int(simple_definition, simple_df):
     """Using a region name as integer raises the expected error"""
     simple_df.rename(region={"World": 1}, inplace=True)
 
     with pytest.raises(ValueError, match=MATCH_FAIL_VALIDATION):
-        simple_nomenclature.validate(simple_df)
+        simple_definition.validate(simple_df)


### PR DESCRIPTION
closes #36
Changed leftover references to the old name of the `DataStructureDefinition` class (`Nomenclature`). 