### PR TITLE
Make `DataStructureDefinition` dimensions customizable

### DIFF
--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -54,11 +54,7 @@ class CodeList(BaseModel):
 
     @classmethod
     def from_directory(
-        cls,
-        name: str,
-        path: Path,
-        file: str = None,
-        ext: str = ".yaml",
+        cls, name: str, path: Path, file: str = None, ext: str = ".yaml",
     ):
         """Initialize a CodeList from a directory with codelist files
 

--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -54,7 +54,11 @@ class CodeList(BaseModel):
 
     @classmethod
     def from_directory(
-        cls, name: str, path: Path, file: str = None, ext: str = ".yaml",
+        cls,
+        name: str,
+        path: Path,
+        file: str = None,
+        ext: str = ".yaml",
     ):
         """Initialize a CodeList from a directory with codelist files
 

--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -16,7 +16,7 @@ def read_validation_schema(i):
     return schema
 
 
-SCHEMA_TYPES = ("variable", "tag", "region")
+SCHEMA_TYPES = ("variable", "tag", "region", "generic")
 SCHEMA_MAPPING = dict([(i, read_validation_schema(i)) for i in SCHEMA_TYPES])
 
 
@@ -101,8 +101,8 @@ class CodeList(BaseModel):
                     tag_dict[tag.name] = [Code.from_dict(a) for a in tag.attributes]
                 continue
 
-            # validate against the schema of this codelist domain
-            validate(_code_list, SCHEMA_MAPPING[name])
+            # validate against the schema of this codelist domain (default `generic`)
+            validate(_code_list, SCHEMA_MAPPING.get(name, SCHEMA_MAPPING["generic"]))
 
             # a "region" codelist assumes a top-level key to be used as attribute
             if name == "region":
@@ -119,7 +119,7 @@ class CodeList(BaseModel):
 
             # add `file` attribute to each element and add to main list
             for item in _code_list:
-                item.set_attribute("file", str(f))
+                item.set_attribute("file", str(f.relative_to(path.parent)))
             code_list.extend(_code_list)
 
         # replace tags by the items of the tag-dictionary

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -23,7 +23,8 @@ class DataStructureDefinition:
         path : str or path-like
             The folder with the project definitions.
         dimensions : list of str, optional
-            List of :meth:`CodeList` names, initialized from a sub-folder of `path`.
+            List of :meth:`CodeList` names. Each CodeList is initialized
+            from a sub-folder of `path` of that name.
         """
         if not isinstance(path, Path):
             path = Path(path)
@@ -32,13 +33,12 @@ class DataStructureDefinition:
             raise NotADirectoryError(f"Definitions directory not found: {path}")
 
         self.dimensions = dimensions
-        for dim in dimensions:
+        for dim in self.dimensions:
             self.__setattr__(dim, CodeList.from_directory(dim, path / dim))
 
         empty = [d for d in self.dimensions if not self.__getattribute__(d)]
         if empty:
-            _empty = ", ".join(empty)
-            raise ValueError(f"Empty codelist: {_empty}")
+            raise ValueError(f"Empty codelist: {', '.join(empty)}")
 
     def validate(self, df: IamDataFrame, dimensions: list = None) -> None:
         """Validate that the coordinates of `df` are defined in the codelists

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -22,7 +22,7 @@ class DataStructureDefinition:
         ----------
         path : str or path-like
             The folder with the project definitions.
-        dimensions : list of str
+        dimensions : list of str, optional
             List of :meth:`CodeList` names, initialized from a sub-folder of `path`.
         """
         if not isinstance(path, Path):
@@ -60,7 +60,7 @@ class DataStructureDefinition:
         ValueError
             If `df` fails validation against any codelist.
         """
-        validate(self, df, dimensions=dimensions)
+        validate(self, df, dimensions=dimensions or self.dimensions)
 
     def to_excel(self, excel_writer, sheet_name="variable_definitions"):
         """Write the variable codelist to an Excel sheet

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -40,7 +40,7 @@ class DataStructureDefinition:
             _empty = ", ".join(empty)
             raise ValueError(f"Empty codelist: {_empty}")
 
-    def validate(self, df: IamDataFrame, dimensions: list=None) -> None:
+    def validate(self, df: IamDataFrame, dimensions: list = None) -> None:
         """Validate that the coordinates of `df` are defined in the codelists
 
         Parameters

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -15,13 +15,15 @@ logger = logging.getLogger(__name__)
 class DataStructureDefinition:
     """Definition of datastructure codelists for dimensions used in the IAMC format"""
 
-    def __init__(self, path):
+    def __init__(self, path, dimensions=["region", "variable"]):
         """
 
         Parameters
         ----------
         path : str or path-like
             The folder with the project definitions.
+        dimensions : list of str
+            List of :meth:`CodeList` names, initialized from a sub-folder of `path`.
         """
         if not isinstance(path, Path):
             path = Path(path)
@@ -29,16 +31,16 @@ class DataStructureDefinition:
         if not path.is_dir():
             raise NotADirectoryError(f"Definitions directory not found: {path}")
 
-        self.variable = CodeList.from_directory("variable", path / "variable")
-        self.region = CodeList.from_directory("region", path / "region")
+        self.dimensions = dimensions
+        for dim in dimensions:
+            self.__setattr__(dim, CodeList.from_directory(dim, path / dim))
 
-        self.dimensions = ["region", "variable"]
         empty = [d for d in self.dimensions if not self.__getattribute__(d)]
         if empty:
             _empty = ", ".join(empty)
             raise ValueError(f"Empty codelist: {_empty}")
 
-    def validate(self, df: IamDataFrame) -> None:
+    def validate(self, df: IamDataFrame, dimensions: list=None) -> None:
         """Validate that the coordinates of `df` are defined in the codelists
 
         Parameters
@@ -46,6 +48,8 @@ class DataStructureDefinition:
         df : IamDataFrame
             An IamDataFrame to be validated against the codelists of this
             DataStructureDefinition.
+        dimensions : list of str, optional
+            Dimensions to perform validation (defaults to all dimensions of self)
 
         Returns
         -------
@@ -56,7 +60,7 @@ class DataStructureDefinition:
         ValueError
             If `df` fails validation against any codelist.
         """
-        validate(self, df)
+        validate(self, df, dimensions=dimensions)
 
     def to_excel(self, excel_writer, sheet_name="variable_definitions"):
         """Write the variable codelist to an Excel sheet

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -16,15 +16,11 @@ def is_subset(x, y):
     return set(to_list(x)).issubset([u or "" for u in to_list(y)])
 
 
-def validate(dsd, df, dimensions=None):
+def validate(dsd, df, dimensions):
     """Validation of an IamDataFrame against codelists of a DataStructureDefinition"""
 
     if not isinstance(df, IamDataFrame):
         df = IamDataFrame(df)
-
-    # by default, validate against all dimensions of the DataStructureDefinition
-    if dimensions is None:
-        dimensions = dsd.dimensions
 
     error = False
 

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def log_error(name, lst):
     """Compile an error message and write to log"""
-    msg = f"The following {name} are not defined in the DataStructureDefinition:"
+    msg = f"The following items are not defined in the '{name}' codelist:"
     logger.error("\n - ".join(map(str, [msg] + lst)))
 
 
@@ -16,48 +16,50 @@ def is_subset(x, y):
     return set(to_list(x)).issubset([u or "" for u in to_list(y)])
 
 
-def validate(dsd, df):
+def validate(dsd, df, dimensions=None):
     """Validation of an IamDataFrame against codelists of a DataStructureDefinition"""
 
     if not isinstance(df, IamDataFrame):
         df = IamDataFrame(df)
 
+    # by default, validate against all dimensions of the DataStructureDefinition
+    if dimensions is None:
+        dimensions = dsd.dimensions
+
     error = False
 
-    # combined validation of variables and units
-    invalid_vars, invalid_units = [], []
-    for variable, unit in df.unit_mapping.items():
-        if variable not in dsd.variable:
-            invalid_vars.append(variable)
-        else:
-            dsd_unit = dsd.variable[variable]["unit"]
-            # fast-pass for unique units in df and the DataStructureDefinition
-            if dsd_unit == unit:
-                continue
-            # full-fledged subset validation
-            if is_subset(unit, dsd_unit):
-                continue
-            invalid_units.append((variable, unit, dsd_unit))
+    if "variable" in dimensions:
+        # combined validation of variables and units
+        invalid_vars, invalid_units = [], []
+        for variable, unit in df.unit_mapping.items():
+            if variable not in dsd.variable:
+                invalid_vars.append(variable)
+            else:
+                dsd_unit = dsd.variable[variable]["unit"]
+                # fast-pass for unique units in df and the DataStructureDefinition
+                if dsd_unit == unit:
+                    continue
+                # full-fledged subset validation
+                if is_subset(unit, dsd_unit):
+                    continue
+                invalid_units.append((variable, unit, dsd_unit))
 
-    if invalid_vars:
-        log_error("variables", invalid_vars)
-        error = True
+        if invalid_vars:
+            log_error("variable", invalid_vars)
+            error = True
 
-    if invalid_units:
-        lst = [f"{v} - expected: {e}, found: {u}" for v, u, e in invalid_units]
-        log_error("units", lst)
-        error = True
+        if invalid_units:
+            lst = [f"{v} - expected: {e}, found: {u}" for v, u, e in invalid_units]
+            log_error("variable", lst)
+            error = True
 
-    # loop over other dimensions for validation
-    cols = [
-        (df.region, dsd.region, "regions"),
-    ]
-
-    for values, codelist, name in cols:
+    # validation of all other dimensions
+    for dim in [d for d in dimensions if d != "variable"]:
+        values, codelist = df.__getattribute__(dim), dsd.__getattribute__(dim)
         invalid = [c for c in values if c not in codelist]
         if invalid:
+            log_error(dim, invalid)
             error = True
-            log_error(name, invalid)
 
     if error:
         raise ValueError("The validation failed. Please check the log for details.")

--- a/nomenclature/validation_schemas/generic_schema.yaml
+++ b/nomenclature/validation_schemas/generic_schema.yaml
@@ -1,0 +1,24 @@
+$schema: 'https://json-schema.org/draft/2020-12/schema'
+title: GenericCodeList
+description: >
+  This schema is used for the validation of generic code-list yaml files.
+type: array
+items:
+  $ref: '#/definitions/Code'
+
+definitions:
+
+  Code:
+    oneOf:
+      - type: object
+        patternProperties:
+          # The key of this dictionary is the code name
+          ^.+$:
+            type: object
+            # The lower-level dictionary are the attributes
+            additionalProperties:
+              type: [ string, number, boolean, "null" ]
+        additionalProperties: false
+        minProperties: 1
+        maxProperties: 1
+      - type: string

--- a/tests/data/custom_dimension_nc/region/regions.yaml
+++ b/tests/data/custom_dimension_nc/region/regions.yaml
@@ -1,0 +1,2 @@
+- common:
+  - World

--- a/tests/data/custom_dimension_nc/scenario/scenarios.yaml
+++ b/tests/data/custom_dimension_nc/scenario/scenarios.yaml
@@ -1,0 +1,3 @@
+- scen_a:
+    attribute: value
+- scen_b

--- a/tests/data/custom_dimension_nc/variable/tag_fuel.yaml
+++ b/tests/data/custom_dimension_nc/variable/tag_fuel.yaml
@@ -1,0 +1,3 @@
+- <Fuel>:
+  - Coal:
+      definition: coal

--- a/tests/data/custom_dimension_nc/variable/variables.yaml
+++ b/tests/data/custom_dimension_nc/variable/variables.yaml
@@ -1,0 +1,9 @@
+- Primary Energy:
+    definition: Total primary energy consumption
+    unit: EJ/yr
+- Primary Energy|<Fuel>:
+    definition: Primary energy consumption of <Fuel>
+    unit: EJ/yr
+- Share|<Fuel>:
+    definition: Share of <Fuel> in the total primary energy mix
+    unit:

--- a/tests/data/structure_validation_fails/definitions/region/regions.yaml
+++ b/tests/data/structure_validation_fails/definitions/region/regions.yaml
@@ -1,2 +1,2 @@
 - common:
-  - World
+    - World

--- a/tests/data/structure_validation_fails/definitions/region/regions.yaml
+++ b/tests/data/structure_validation_fails/definitions/region/regions.yaml
@@ -1,2 +1,2 @@
 - common:
-    - World
+  - World

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,9 +5,26 @@ from nomenclature import DataStructureDefinition, create_yaml_from_xlsx
 from conftest import TEST_DATA_DIR
 
 
+def test_definition_with_custom_dimension(simple_definition):
+    """Check initializing a DataStructureDefinition with a custom dimension"""
+
+    obs = DataStructureDefinition(
+        TEST_DATA_DIR / "custom_dimension_nc",
+        dimensions=["region", "variable", "scenario"],
+    )
+
+    # check that "standard" dimensions are identical to simple test definitions
+    assert obs.region == simple_definition.region
+    assert obs.variable == simple_definition.variable
+
+    # check that "custom" dimensions are as expected
+    file = "scenario/scenarios.yaml"
+    assert obs.scenario["scen_a"] == {"attribute": "value", "file": file}
+    assert obs.scenario["scen_b"] == {"file": file}
+
+
 def test_nonexisting_path_raises():
-    """Check that initializing a DataStructureDefinition with a non-existing path
-    raises"""
+    """Check that initializing a DataStructureDefinition with non-existing path fails"""
     match = "Definitions directory not found: foo"
     with pytest.raises(NotADirectoryError, match=match):
         DataStructureDefinition("foo")


### PR DESCRIPTION
This PR allows to specify "custom" (aka generic) CodeList dimensions for a `DataStructureDefinition`. This can be used to validate against an IamDataFrame against a list of valid "scenario" names or (if it exists) a list of "subannual" categorical timeslices.

As a side bonus, the PR also closes #16.