### PR TITLE
Skip region aggregation

### DIFF
--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -257,6 +257,7 @@ class RegionProcessor(BaseModel):
                             }
                             for var, kwargs in self.definition.variable.items()
                             if var in model_df.variable
+                            and not kwargs.get("skip-region-aggregation", False)
                         }
                         for var, kwargs in vars.items():
                             agg_df = model_df.aggregate_region(

--- a/tests/data/region_processing/skip_aggregation/dsd/region/regions.yaml
+++ b/tests/data/region_processing/skip_aggregation/dsd/region/regions.yaml
@@ -1,0 +1,5 @@
+- common:
+  - World
+- model_native:
+  - region_A
+  - region_B

--- a/tests/data/region_processing/skip_aggregation/dsd/variable/variables.yaml
+++ b/tests/data/region_processing/skip_aggregation/dsd/variable/variables.yaml
@@ -1,0 +1,4 @@
+- Primary Energy:
+    definition: Total primary energy consumption
+    unit: EJ/yr
+    skip-region-aggregation: true

--- a/tests/data/region_processing/skip_aggregation/mappings/model_a.yaml
+++ b/tests/data/region_processing/skip_aggregation/mappings/model_a.yaml
@@ -1,0 +1,8 @@
+model: m_a
+native_regions:
+  - region_A
+  - region_B
+common_regions:
+  - World:
+    - region_A
+    - region_B

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -320,3 +320,24 @@ def test_region_processing_weighted_aggregation():
     )
     obs = rp.apply(test_df)
     assert_iamframe_equal(obs, exp)
+
+
+def test_region_processing_skip_aggregation():
+    test_df = IamDataFrame(
+        pd.DataFrame(
+            [
+                ["m_a", "s_a", "region_A", "Primary Energy", "EJ/yr", 1, 2],
+                ["m_a", "s_a", "region_B", "Primary Energy", "EJ/yr", 3, 4],
+            ],
+            columns=IAMC_IDX + [2005, 2010],
+        )
+    )
+    exp = test_df
+    dsd = DataStructureDefinition(
+        TEST_DATA_DIR / "region_processing/skip_aggregation/dsd"
+    )
+    rp = RegionProcessor.from_directory(
+        TEST_DATA_DIR / "region_processing/skip_aggregation/mappings", dsd
+    )
+    obs = rp.apply(test_df)
+    assert_iamframe_equal(obs, exp)


### PR DESCRIPTION
closes #40.

It is now possible to skip region aggregation by adding: `skip-region-aggregation: true` to a variable definition.

Three things to note:
* The boolean value `true` needs to be lowercase
* By default region aggregation is **not** skipped. The current pattern is opt-out.
* The variable will still be kept for model native regions.