### PR TITLE
Use relative paths in RegionAggregationMapping

### DIFF
--- a/nomenclature/region_mapping_models.py
+++ b/nomenclature/region_mapping_models.py
@@ -24,13 +24,6 @@ class RegionNameCollisionError(PydanticValueError):
     code = "region_name_collision"
     msg_template = "Name collision in {location} for {duplicates} in {file}"
 
-    def __init__(self, location: str, duplicates: Sequence, file: Path) -> None:
-        super().__init__(
-            location=location,
-            duplicates=duplicates,
-            file=file.relative_to(Path.cwd()),
-        )
-
 
 class NativeRegion(BaseModel):
     name: str
@@ -61,7 +54,9 @@ class RegionAggregationMapping(BaseModel):
         if duplicates:
             # Raise the custom RegionNameCollisionError and give the parameters
             # duplicates and file.
-            raise RegionNameCollisionError("native regions", duplicates, values["file"])
+            raise RegionNameCollisionError(
+                location="native regions", duplicates=duplicates, file=values["file"]
+            )
         return v
 
     @validator("common_regions")
@@ -69,7 +64,9 @@ class RegionAggregationMapping(BaseModel):
         names = [cr.name for cr in v]
         duplicates = [item for item, count in Counter(names).items() if count > 1]
         if duplicates:
-            raise RegionNameCollisionError("common regions", duplicates, values["file"])
+            raise RegionNameCollisionError(
+                location="common regions", duplicates=duplicates, file=values["file"]
+            )
         return v
 
     @root_validator()
@@ -98,7 +95,9 @@ class RegionAggregationMapping(BaseModel):
         overlap = list(native_region_names & common_region_names)
         if overlap:
             raise RegionNameCollisionError(
-                "native and common regions", overlap, values["file"]
+                location="native and common regions",
+                duplicates=overlap,
+                file=values["file"],
             )
         return values
 
@@ -115,10 +114,10 @@ class RegionAggregationMapping(BaseModel):
             validate(mapping_input, schema)
         except ValidationError as e:
             # Add file information in case of error
-            raise ValidationError(f"{e.message} in {file}")
+            raise ValidationError(f"{e.message} in {file.relative_to(Path.cwd())}")
 
         # Add the file name to mapping_input
-        mapping_input["file"] = file
+        mapping_input["file"] = file.relative_to(Path.cwd())
 
         # Reformat the "native_regions"
         if "native_regions" in mapping_input:
@@ -165,16 +164,9 @@ class RegionAggregationMapping(BaseModel):
 
 class ModelMappingCollisionError(PydanticValueError):
     code = "model_mapping_collision"
-    msg_template = "Multiple region aggregation mappings for model {model} in {files}"
-
-    def __init__(
-        self, mapping1: RegionAggregationMapping, mapping2: RegionAggregationMapping
-    ) -> None:
-        files = (
-            mapping1.file.relative_to(Path.cwd()),
-            mapping2.file.relative_to(Path.cwd()),
-        )
-        super().__init__(model=mapping1.model, files=files)
+    msg_template = (
+        "Multiple region aggregation mappings for model {model} in [{file1}, {file2}]"
+    )
 
 
 class RegionNotDefinedError(PydanticValueError):
@@ -182,10 +174,6 @@ class RegionNotDefinedError(PydanticValueError):
     msg_template = (
         "Region(s) {region} in {file} not defined in the DataStructureDefinition"
     )
-
-    def __init__(self, region, file) -> None:
-        self.file = file.relative_to(Path.cwd())
-        super().__init__(region=region, file=file)
 
 
 class RegionProcessor(BaseModel):
@@ -207,14 +195,18 @@ class RegionProcessor(BaseModel):
             if mapping.model not in mapping_dict:
                 mapping_dict[mapping.model] = mapping
             else:
-                raise ModelMappingCollisionError(mapping, mapping_dict[mapping.model])
+                raise ModelMappingCollisionError(
+                    model=mapping.model,
+                    file1=mapping.file,
+                    file2=mapping_dict[mapping.model].file,
+                )
         return cls(definition=definition, mappings=mapping_dict)
 
     @validator("mappings", each_item=True)
     def validate_mapping(cls, v, values):
         invalid = [c for c in v.all_regions if c not in values["definition"].region]
         if invalid:
-            raise RegionNotDefinedError(invalid, v.file)
+            raise RegionNotDefinedError(region=invalid, file=v.file)
         return v
 
     def apply(self, df: IamDataFrame) -> IamDataFrame:

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -1,15 +1,18 @@
 import copy
+from pathlib import Path
+
 import jsonschema
+import pandas as pd
 import pydantic
 import pytest
-import pandas as pd
 from nomenclature.core import DataStructureDefinition
 from nomenclature.region_mapping_models import (
+    ModelMappingCollisionError,
     RegionAggregationMapping,
     RegionProcessor,
-    ModelMappingCollisionError,
 )
-from pyam import IAMC_IDX, assert_iamframe_equal, IamDataFrame
+from pyam import IAMC_IDX, IamDataFrame, assert_iamframe_equal
+
 from conftest import TEST_DATA_DIR
 
 TEST_FOLDER_REGION_MAPPING = TEST_DATA_DIR / "region_aggregation"
@@ -23,7 +26,7 @@ def test_mapping():
     )
     exp = {
         "model": "model_a",
-        "file": TEST_FOLDER_REGION_MAPPING / mapping_file,
+        "file": (TEST_FOLDER_REGION_MAPPING / mapping_file).relative_to(Path.cwd()),
         "native_regions": [
             {"name": "region_a", "rename": "alternative_name_a"},
             {"name": "region_b", "rename": "alternative_name_b"},
@@ -100,7 +103,9 @@ def test_region_processor_working(simple_definition):
     exp_data = [
         {
             "model": "model_a",
-            "file": TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml",
+            "file": (
+                TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml"
+            ).relative_to(Path.cwd()),
             "native_regions": [
                 {"name": "World", "rename": None},
             ],
@@ -108,7 +113,9 @@ def test_region_processor_working(simple_definition):
         },
         {
             "model": "model_b",
-            "file": TEST_DATA_DIR / "regionprocessor_working/mapping_2.yaml",
+            "file": (
+                TEST_DATA_DIR / "regionprocessor_working/mapping_2.yaml"
+            ).relative_to(Path.cwd()),
             "native_regions": None,
             "common_regions": [
                 {


### PR DESCRIPTION
closes #46.

Changed paths from absolute to relative for shorter error messages.
Additional side benefit is that all of our custom pydantic errors no longer need an extra `__init__` and are therefore shorter