### PR TITLE
Change package name when reading version from metadata

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -18,4 +18,4 @@ logger = logging.getLogger(__name__)
 try:
     __version__ = get_version(Path(__file__).parents[1])
 except LookupError:
-    __version__ = version("nomenclature")
+    __version__ = version("nomenclature-iamc")


### PR DESCRIPTION
Unit tests on https://github.com/openENTRANCE/openentrance fail, see https://github.com/openENTRANCE/openentrance/runs/4265491713?check_suite_focus=true - this is because the package is now called "nomenclature-iamc" in the metadata of the Python installation.