### PR TITLE
Add readthedocs.yml for documentation build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,29 @@
+# This workflow installs the package and builds the docs
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: build the docs
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies and package for building the docs
+      run: pip install .[tests,docs]
+
+    - name: Build the docs
+      run: make --directory=doc html

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,8 @@
+version: 2
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - tests

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,3 +6,4 @@ python:
       path: .
       extra_requirements:
         - tests
+        - docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ setup_requires =
 [options.extras_require]
 tests =
     pytest
+docs =
+    sphinx
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This PR adds the _readthedocs.yml_ file for the documentation build on [RTD](https://readthedocs.org/). It supports the closing of issue #53. 