### PR TITLE
Add a Sphinx-docs page for the CLI

### DIFF
--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -1,0 +1,6 @@
+Command line interface
+======================
+
+.. click:: nomenclature:cli
+   :prog: nomenclature
+   :nested: full

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,6 +36,7 @@ release = nomenclature.__version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx_click",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,6 +35,7 @@ Table of Contents
    :maxdepth: 2
 
    api
+   cli
 
 Acknowledgement
 ===============

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 
 from nomenclature.codes import CodeList  # noqa
 from nomenclature.core import DataStructureDefinition, create_yaml_from_xlsx  # noqa
-from nomenclature.testing import assert_valid_yaml  # noqa
+from nomenclature.cli import cli  # noqa
 from nomenclature.region_mapping_models import (  # noqa
     RegionProcessor,
     RegionAggregationMapping,

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -1,0 +1,20 @@
+import click
+from pathlib import Path
+
+from nomenclature.testing import assert_valid_yaml, assert_valid_structure
+
+cli = click.Group()
+
+
+@cli.command("validate-yaml")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+def cli_valid_yaml(path: Path):
+    assert_valid_yaml(path)
+
+
+@cli.command("validate-project")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+def cli_valid_project(path: Path):
+    assert_valid_yaml(path)
+    assert_valid_structure(path)
+

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -9,12 +9,14 @@ cli = click.Group()
 @cli.command("validate-yaml")
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 def cli_valid_yaml(path: Path):
+    """Assert that all yaml files in `path` can be parsed without errors"""
     assert_valid_yaml(path)
 
 
 @cli.command("validate-project")
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 def cli_valid_project(path: Path):
+    """Assert that `path` is a valid project nomenclature"""
     assert_valid_yaml(path)
     assert_valid_structure(path)
 

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -19,4 +19,3 @@ def cli_valid_project(path: Path):
     """Assert that `path` is a valid project nomenclature"""
     assert_valid_yaml(path)
     assert_valid_structure(path)
-

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -2,26 +2,9 @@ import yaml
 import logging
 from pathlib import Path
 
-import click
-
 import nomenclature
 
 logger = logging.getLogger(__name__)
-
-cli = click.Group()
-
-
-@cli.command("validate-yaml")
-@click.argument("path", type=click.Path(exists=True, path_type=Path))
-def cli_valid_yaml(path: Path):
-    assert_valid_yaml(path)
-
-
-@cli.command("validate-project")
-@click.argument("path", type=click.Path(exists=True, path_type=Path))
-def cli_valid_project(path: Path):
-    assert_valid_yaml(path)
-    assert_valid_structure(path)
 
 
 def assert_valid_yaml(path: Path):

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -28,8 +28,12 @@ def assert_valid_yaml(path: Path):
 
 
 def assert_valid_structure(path: Path):
-    """Check that "definitions" folder in `path` exists and
-    can be initialized without errors"""
+    """Assert that `path` is a valid project nomenclature and can be initialized
+
+    Valid structure:
+    - A `definitions` folder is required and must be a valid `DataStructureDefinition`
+    - If a `mappings` folder exists, it must be a valid `RegionProcessor`
+    """
     definition = nomenclature.DataStructureDefinition(path / "definitions")
     if (path / "mappings").is_dir():
         nomenclature.RegionProcessor.from_directory(path / "mappings", definition)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,10 +29,11 @@ tests =
     pytest
 docs =
     sphinx
+    sphinx-click
 
 [flake8]
 max-line-length = 88
 
 [options.entry_points]
 console_scripts =
-    nomenclature = nomenclature.testing:cli
+    nomenclature = nomenclature:cli

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
-from nomenclature.testing import cli, assert_valid_yaml, assert_valid_structure
+from nomenclature import cli
+from nomenclature.testing import assert_valid_yaml, assert_valid_structure
 import pytest
 import pydantic
 


### PR DESCRIPTION
This PR adds an automated CLI-documentation page (using **sphinx-click**, see https://sphinx-click.readthedocs.io).

In anticipation of future CLI methods that are not part of the testing module, I also moved the CLI-part to an independent CLI module.

Contributes to the closing of #53 