### PR TITLE
Add numpydoc for sphinx

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,7 @@ release = nomenclature.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx_click",

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ tests =
 docs =
     sphinx
     sphinx-click
+    numpydoc
 
 [flake8]
 max-line-length = 88

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -141,8 +141,9 @@ def test_region_processor_not_defined(simple_definition):
     # Test a RegionProcessor with regions that are not defined in the data structure
     # definition
     error_msg = (
-        "model_b\n.*region_a.*mapping_2.yaml.*value_error.region_not_defined."
-        "*\n.*model_a\n.*region_a.*mapping_1.yaml.*value_error.region_not_defined"
+        "model_(a|b)\n.*region_a.*mapping_(1|2).yaml.*value_error.region_not_defined."
+        "*\n.*model_(a|b)\n.*region_a.*mapping_(1|2).yaml.*value_error."
+        "region_not_defined"
     )
     with pytest.raises(pydantic.ValidationError, match=error_msg):
         RegionProcessor.from_directory(
@@ -151,7 +152,7 @@ def test_region_processor_not_defined(simple_definition):
 
 
 def test_region_processor_duplicate_model_mapping(simple_definition):
-    error_msg = ".*model_a.*mapping_1.yaml.*mapping_2.yaml"
+    error_msg = ".*model_a.*mapping_(1|2).yaml.*mapping_(1|2).yaml"
     with pytest.raises(ModelMappingCollisionError, match=error_msg):
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_duplicate", simple_definition


### PR DESCRIPTION
While working on #64 I noticed that I got some sphinx warnings.

``` bash
WARNING: Unexpected section title.

Parameters
----------
```

It seems this has to do with sphinx not recognizing the numpydoc style. If you compare the [pyam api docs](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html) to the [nomenclature api docs](https://nomenclature-iamc.readthedocs.io/en/latest/api.html) you can see that the doc strings are not correctly rendered for nomenclature. 

The issue is that numpydoc was missing as an extension for sphinx.
This PR fixes that. 