### PR TITLE
Change continue to else in CodeList.from_directory

### DIFF
--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -99,10 +99,10 @@ class CodeList(BaseModel):
                 for item in _code_list:
                     tag = Tag.from_dict(mapping=item)
                     tag_dict[tag.name] = [Code.from_dict(a) for a in tag.attributes]
+
             # if the file does not start with tag, process normally
             else:
-                # validate against the schema of this codelist domain (default
-                # `generic`)
+                # validate the schema of this codelist domain (default `generic`)
                 validate(
                     _code_list, SCHEMA_MAPPING.get(name, SCHEMA_MAPPING["generic"])
                 )

--- a/nomenclature/codes.py
+++ b/nomenclature/codes.py
@@ -99,28 +99,33 @@ class CodeList(BaseModel):
                 for item in _code_list:
                     tag = Tag.from_dict(mapping=item)
                     tag_dict[tag.name] = [Code.from_dict(a) for a in tag.attributes]
-                continue
-
-            # validate against the schema of this codelist domain (default `generic`)
-            validate(_code_list, SCHEMA_MAPPING.get(name, SCHEMA_MAPPING["generic"]))
-
-            # a "region" codelist assumes a top-level key to be used as attribute
-            if name == "region":
-                _region_code_list = []  # save refactored list as new (temporary) object
-                for top_level_cat in _code_list:
-                    for top_key, _codes in top_level_cat.items():
-                        for item in _codes:
-                            item = Code.from_dict(item)
-                            item.set_attribute("hierarchy", top_key)
-                            _region_code_list.append(item)
-                _code_list = _region_code_list
+            # if the file does not start with tag, process normally
             else:
-                _code_list = [Code.from_dict(_dict) for _dict in _code_list]
+                # validate against the schema of this codelist domain (default
+                # `generic`)
+                validate(
+                    _code_list, SCHEMA_MAPPING.get(name, SCHEMA_MAPPING["generic"])
+                )
 
-            # add `file` attribute to each element and add to main list
-            for item in _code_list:
-                item.set_attribute("file", str(f.relative_to(path.parent)))
-            code_list.extend(_code_list)
+                # a "region" codelist assumes a top-level key to be used as attribute
+                if name == "region":
+                    _region_code_list = (
+                        []
+                    )  # save refactored list as new (temporary) object
+                    for top_level_cat in _code_list:
+                        for top_key, _codes in top_level_cat.items():
+                            for item in _codes:
+                                item = Code.from_dict(item)
+                                item.set_attribute("hierarchy", top_key)
+                                _region_code_list.append(item)
+                    _code_list = _region_code_list
+                else:
+                    _code_list = [Code.from_dict(_dict) for _dict in _code_list]
+
+                # add `file` attribute to each element and add to main list
+                for item in _code_list:
+                    item.set_attribute("file", str(f.relative_to(path.parent)))
+                code_list.extend(_code_list)
 
         # replace tags by the items of the tag-dictionary
         for tag, tag_attrs in tag_dict.items():

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -141,8 +141,9 @@ def test_region_processor_not_defined(simple_definition):
     # Test a RegionProcessor with regions that are not defined in the data structure
     # definition
     error_msg = (
-        "model_b\n.*region_a.*mapping_2.yaml.*value_error.region_not_defined."
-        "*\n.*model_a\n.*region_a.*mapping_1.yaml.*value_error.region_not_defined"
+        "model_(a|b)\n.*region_a.*mapping_(1|2).yaml.*value_error.region_not_defined."
+        "*\n.*model_(a|b)\n.*region_a.*mapping_(1|2).yaml.*value_error."
+        "region_not_defined"
     )
     with pytest.raises(pydantic.ValidationError, match=error_msg):
         RegionProcessor.from_directory(
@@ -151,7 +152,7 @@ def test_region_processor_not_defined(simple_definition):
 
 
 def test_region_processor_duplicate_model_mapping(simple_definition):
-    error_msg = ".*model_a.*mapping_1.yaml.*mapping_2.yaml"
+    error_msg = ".*model_a.*mapping_(1|2).yaml.*mapping_(1|2).yaml"
     with pytest.raises(ModelMappingCollisionError, match=error_msg):
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_duplicate", simple_definition


### PR DESCRIPTION
This is a minimal refactor changing the `continue` statement inside the `if` that checks if a yaml file starts with "tag_" to an `else`.

When looking at the code it took me a while to realize that the rest of the processing after the `if` only affects non-tag files. Changing it to an else makes that easier to understand in my opinion.
The functionality stays exactly the same.