### PR TITLE
Update "Getting started" and "api" sections of the documentation

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -5,9 +5,9 @@
 API documentation
 =================
 
-.. _process-function:
+.. _toplevel-functions:
 
-Process function
+Top-level functions
 ----------------
 
 .. autofunction:: process

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -5,6 +5,14 @@
 API documentation
 =================
 
+.. _process-function:
+
+Process function
+----------------
+
+.. autofunction:: process
+
+
 DataStructureDefinition
 -----------------------
 
@@ -15,5 +23,5 @@ DataStructureDefinition
 Region processing 
 -----------------
 
-.. automodule:: nomenclature.region_mapping_models
+.. automodule:: nomenclature.processor.region
    :members:

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -29,9 +29,11 @@ attributes (e.g., description, unit, parent region).
 A **RegionAggregationMapping** is a mapping that defines on a per-model basis how model
 native regions should be renamed and aggregated to comparison regions.
 
-
-Before the :ref:`minimum-working-example` can be covered, the required directory
-structure for definitions and mappings needs to be addressed. 
+In order to reduce the amount of code required, there is a convenience function called
+*process* which takes a **DataStructureDefinition** and a **RegionProcessor** as input.
+Details will be covered in :ref:`minimum-working-example`. Before this can be explained,
+however, the required directory structure for definitions and mappings needs to be
+discussed. 
 
 .. _dir-structure:
 
@@ -90,35 +92,34 @@ The following outlines how to use the nomenclature package:
 
 .. code-block:: python
 
-   # Import the necessary libraries
-   import pyam
-   from nomenclature import DataStructureDefinition, RegionProcessor
-   
-   # Initialize DataStructureDefinition and RegionProcessor giving them the
-   # directories where the codelists and mappings are defined as input.
-   dsd = DataStructureDefinition("definitions/")
-   # Only to be used if there are mappings!
-   rp = RegionProcessor.from_directory("mappings/", dsd)
-
-   # Read the data using pyam
-   iam_results_file = "some file"
-   df = pyam.IamDataFrame(iam_results_file)
-
-   # Validate that the data frame only contains allowed regions and variables
-   dsd.validate(df)
-   # Apply region processing to the data
-   # Only to be used if there are mappings!
-   df = rp.apply(df)
+  # Import the necessary libraries
+  import pyam
+  from nomenclature import DataStructureDefinition, RegionProcessor, process
+  
+  # Initialize DataStructureDefinition and RegionProcessor giving them the
+  # directories where the codelists and mappings are defined as input.
+  dsd = DataStructureDefinition("definitions/")
+  
+  # Only to be used if there are mappings!
+  rp = RegionProcessor.from_directory("mappings/", dsd)
+  
+  # Read the data using pyam
+  iam_results_file = "some file"
+  df = pyam.IamDataFrame(iam_results_file)
+  
+  # Using the process function we perform the validation of allowed regions and
+  # variables as well as the aggregation (if applicable) in one step.
+  df = process(df, dsd, processor=rp)
 
 **Notes**
 
-* The pyam library is required as *DataStructureDefinition.validate()* and
-  *RegionProcessor.apply()* take a *pyam.IamDataFrame* as input.
+* The pyam library is required as *process* takes a *pyam.IamDataFrame* as input.
 
 * *DataStructureDefinition* and *RegionProcessor* are initialized from directories
   containing yaml files. See :ref:`dir-structure` for details. 
 
-* *DataStructureDefinition.apply()* returns *None* if the data frame only contains   
-  allowed values and raises an error otherwise.
+* The processor argument of *process* is optional and may only to be used if there are  
+  model mappings. See :ref:`process-function` for details.
 
-* *RegionProcessor* is only to be used if there are model mappings.
+* If not all dimensions of the **DataStructureDefinition** should be validated, a
+  *dimensions* argument in form of a list of strings can be provided. Only the provided dimensions will then be validated. See :ref:`process-function` for details.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -96,19 +96,16 @@ The following outlines how to use the nomenclature package:
   import pyam
   from nomenclature import DataStructureDefinition, RegionProcessor, process
   
-  # Initialize DataStructureDefinition and RegionProcessor giving them the
-  # directories where the codelists and mappings are defined as input.
-  dsd = DataStructureDefinition("definitions/")
+  # Initialize DataStructureDefinition from a suitable directory
+  dsd = DataStructureDefinition("definitions")
   
-  # Only to be used if there are mappings!
-  rp = RegionProcessor.from_directory("mappings/", dsd)
+  # Initialize a RegionProcessor from a suitable directory that has the mappings
+  rp = RegionProcessor.from_directory("mappings")
   
   # Read the data using pyam
-  iam_results_file = "some file"
-  df = pyam.IamDataFrame(iam_results_file)
+  df = pyam.IamDataFrame("/path/to/file")
   
-  # Using the process function we perform the validation of allowed regions and
-  # variables as well as the aggregation (if applicable) in one step.
+  # Perform the validation and apply the region aggregation
   df = process(df, dsd, processor=rp)
 
 **Notes**
@@ -122,4 +119,4 @@ The following outlines how to use the nomenclature package:
   model mappings. See :ref:`process-function` for details.
 
 * If not all dimensions of the **DataStructureDefinition** should be validated, a
-  *dimensions* argument in form of a list of strings can be provided. Only the provided dimensions will then be validated. See :ref:`process-function` for details.
+  *dimensions* argument in form of a list of strings can be provided. Only the provided dimensions will then be validated. See :func:`nomenclature.process` for details.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -3,44 +3,35 @@
 Getting started
 ===============
 
-The nomenclature package facilitates working with data templates that follow the format
+The nomenclature package facilitates working with codelists that follow the format
 developed by the `Integrated Assessment Modeling Consortium (IAMC)
 <https://www.iamconsortium.org>`__. It supports validation of scenario data and region
-processing, which consists of renaming and aggregation of model “native regions” to
+processing, which consists of renaming of model “native regions” and aggregation to
 “common regions” used in a project.
 
 There are two main classes that the user interacts with when using the nomenclature
-package, **DataStructureDefinition** and **RegionProcessor**. Additionally, there are a
-number of auxiliary classes which are used by the two main ones to facilitate validation
-and region processing, the two most important ones being **CodeList** and
-**RegionAggregationMapping** (a full list of all classes can be found in :ref:`api`).
+package, **DataStructureDefinition** and **RegionProcessor** (a full list of all classes can be found in :ref:`api`). 
 
-A **DataStructureDefinition** contains **CodeLists** for *variables* (including units)
-and *regions* to be used in a model comparison or scenario exercise following the IAMC
-data format.
+A **DataStructureDefinition** contains codelists which define allowed *variables*
+(including units) and *regions* to be used in a model comparison or scenario exercise
+following the IAMC data format.
 
-A **RegionProcessor** holds a list of RegionAggregationMappings and a
-DataStructureDefinition. This class is used to facilitate region processing for model
-comparison studies.
+A **RegionProcessor**  is used to facilitate region processing for model comparison
+studies. It holds a list of model specific mappings which define renaming of native
+regions and aggregation to common regions.
 
-A **CodeList** is a list of "allowed terms" (or codes), where each term can have several
-attributes (e.g., description, unit, parent region).
-
-A **RegionAggregationMapping** is a mapping that defines on a per-model basis how model
-native regions should be renamed and aggregated to comparison regions.
-
-In order to reduce the amount of code required, there is a convenience function called
-*process* which takes a **DataStructureDefinition** and a **RegionProcessor** as input.
-Details will be covered in :ref:`minimum-working-example`. Before this can be explained,
-however, the required directory structure for definitions and mappings needs to be
-discussed. 
+The top-level function *process()* provides a direct entrypoint to validating scenario
+data and applying region processing. Details will be covered in
+:ref:`minimum-working-example`. Before that, the required directory structure for
+definitions and mappings is discussed. 
 
 .. _dir-structure:
 
 Directory structure for definitions and mappings
 ------------------------------------------------
 
-This is the directory structure that needs to be in place in order for the validation and region processing to work:
+This is the directory structure that needs to be in place in order for the validation
+and region processing to work:
 
 .. code-block:: bash
 
@@ -61,11 +52,11 @@ This is the directory structure that needs to be in place in order for the valid
 * The **DataStructureDefinition** will be initialized from the *definitions* folder.
 
 * The **RegionProcessor** will be initialized from the *mappings* folder. If the project
-  has no model specific mappings, this folder can also be omitted. In this case,
-  however, *RegionProcessor* **must not** be used as it would try to read a non-existent
-  directory causing the program to crash.
+  has no model specific mappings, this folder can also be omitted. In this case
+  *RegionProcessor* **must not** be used as it would try to read a non-existent
+  directory causing an error.
 
-* Inside the *definitions* directory each "dimension", in our case *variable* and
+* Inside the *definitions* directory, each "dimension", in our case *variable* and
   *region*, must live in its own sub-directory.
 
 * The directories inside the *definitions* folder, *variable* and *region* are special
@@ -116,7 +107,8 @@ The following outlines how to use the nomenclature package:
   containing yaml files. See :ref:`dir-structure` for details. 
 
 * The processor argument of *process* is optional and may only to be used if there are  
-  model mappings. See :ref:`process-function` for details.
+  model mappings. See :ref:`toplevel-functions` for details.
 
 * If not all dimensions of the **DataStructureDefinition** should be validated, a
-  *dimensions* argument in form of a list of strings can be provided. Only the provided dimensions will then be validated. See :func:`nomenclature.process` for details.
+  *dimensions* argument in form of a list of strings can be provided. Only the provided
+  dimensions will then be validated. See :ref:`toplevel-functions` for details.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,10 +23,10 @@ Release v\ |version|.
 Overview
 ========
 
-This package facilitates working with data templates that follow the format developed by
-the `Integrated Assessment Modeling Consortium (IAMC) <https://www.iamconsortium.org>`_.
-It supports validation of scenario data and region processing, which consists of
-renaming and aggregation of model "native regions" to "common regions" used in a project.
+This package facilitates working with codelists that follow the format developed by the
+`Integrated Assessment Modeling Consortium (IAMC) <https://www.iamconsortium.org>`_. It
+supports validation of scenario data and region processing, which consists of renaming
+and aggregation of model "native regions" to "common regions" used in a project.
 
 Those two tasks are carried out by two classes:
 

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -17,9 +17,8 @@ def process(
 ) -> pyam.IamDataFrame:
     """Function for validation and region aggregation in one step
 
-    Since there are some subtleties in the order of applying region processing and
-    validation, this function is the recommended way of using the nomenclature package
-    as it takes care of subtleties.
+   This function is the recommended way of using the nomenclature package
+   for validation and region-processing.
 
     Parameters
     ----------
@@ -27,12 +26,10 @@ def process(
         Input data to be validated and aggregated.
     dsd : DataStructureDefinition
         Data templates that are used for validation.
-    dimensions : Optional[List[str]], optional
-        List of dimensions that will be used in the validation, if None all
-        dsd.dimensions will be used, by default None
+    dimensions : list, optional
+        Dimensions to be used in the validation, defaults to all dimensions defined in *dsd* 
     processor : Optional[RegionProcessor], optional
-        Region processor that will perform region renaming and aggregation if provided,
-        by default None
+        Region processor that will perform region renaming and aggregation if provided
 
     Returns
     -------

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -1,5 +1,7 @@
 import copy
-from pyam import IamDataFrame
+from typing import List, Optional
+
+import pyam
 from pydantic import validate_arguments
 
 from nomenclature.definition import DataStructureDefinition
@@ -8,11 +10,49 @@ from nomenclature.processor.region import RegionProcessor
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def process(
-    df: IamDataFrame,
+    df: pyam.IamDataFrame,
     dsd: DataStructureDefinition,
-    dimensions: list = None,
-    processor: RegionProcessor = None,
-):
+    dimensions: Optional[List[str]] = None,
+    processor: Optional[RegionProcessor] = None,
+) -> pyam.IamDataFrame:
+    """Function for validation and region aggregation in one step
+
+    Since there are some subtleties in the order of applying region processing and
+    validation, this function is the recommended way of using the nomenclature package
+    as it takes care of subtleties.
+
+    Parameters
+    ----------
+    df : pyam.IamDataFrame
+        Input data to be validated and aggregated.
+    dsd : DataStructureDefinition
+        Data templates that are used for validation.
+    dimensions : Optional[List[str]], optional
+        List of dimensions that will be used in the validation, if None all
+        dsd.dimensions will be used, by default None
+    processor : Optional[RegionProcessor], optional
+        Region processor that will perform region renaming and aggregation if provided,
+        by default None
+
+    Returns
+    -------
+    pyam.IamDataFrame
+        Processed data frame
+
+    Notes
+    -----
+    The above mentioned "subtleties" in the order of operations is related to the fact
+    that as part of the region processing, three things can occur:
+
+    1. Model native regions not mentioned in the model mapping will be dropped
+    2. Model native regions can be renamed
+    3. Common regions based on aggregated model native regions weill be newly created.
+
+    As each of these three can affects the outcome of the region validation, this
+    validation step needs to be performed *after* aggregation.
+    Since none of the other dimensions (e.g. variables, scenarios, etc...) are affected
+    by aggregation they can be validated before.
+    """
     # The deep copy is needed so we don't alter dsd in dimensions.remove("region")
     dimensions = copy.deepcopy(dimensions or dsd.dimensions)
     if processor is None:

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -17,38 +17,31 @@ def process(
 ) -> pyam.IamDataFrame:
     """Function for validation and region aggregation in one step
 
-   This function is the recommended way of using the nomenclature package
-   for validation and region-processing.
+    This function is the recommended way of using the nomenclature package. It performs
+    two operations:
+
+    * Validation against the codelists of a DataStructureDefinition
+    * Region-processing, which can consist of three parts:
+        1. Model native regions not mentioned in the model mapping will be dropped
+        2. Model native regions can be renamed
+        3. Aggregation from model native regions to "common regions"
 
     Parameters
     ----------
     df : pyam.IamDataFrame
         Input data to be validated and aggregated.
     dsd : DataStructureDefinition
-        Data templates that are used for validation.
+        Codelists that are used for validation.
     dimensions : list, optional
-        Dimensions to be used in the validation, defaults to all dimensions defined in *dsd* 
-    processor : Optional[RegionProcessor], optional
+        Dimensions to be used in the validation, defaults to all dimensions defined in
+        *dsd*
+    processor : RegionProcessor, optional
         Region processor that will perform region renaming and aggregation if provided
 
     Returns
     -------
     pyam.IamDataFrame
         Processed data frame
-
-    Notes
-    -----
-    The above mentioned "subtleties" in the order of operations is related to the fact
-    that as part of the region processing, three things can occur:
-
-    1. Model native regions not mentioned in the model mapping will be dropped
-    2. Model native regions can be renamed
-    3. Common regions based on aggregated model native regions weill be newly created.
-
-    As each of these three can affects the outcome of the region validation, this
-    validation step needs to be performed *after* aggregation.
-    Since none of the other dimensions (e.g. variables, scenarios, etc...) are affected
-    by aggregation they can be validated before.
     """
     # The deep copy is needed so we don't alter dsd in dimensions.remove("region")
     dimensions = copy.deepcopy(dimensions or dsd.dimensions)


### PR DESCRIPTION
After the refactoring in #73, I've now updated the getting started and api sections.

Next up will be the usage section but I'd prefer to keep those PRs separate.