### PR TITLE
Clean up API docs

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -19,9 +19,14 @@ DataStructureDefinition
 .. autoclass:: DataStructureDefinition
    :members:
 
+.. autoclass:: nomenclature.codelist.CodeList
+   :members:
 
 Region processing 
 -----------------
 
-.. automodule:: nomenclature.processor.region
+.. autoclass:: RegionProcessor
+   :members:
+
+.. autoclass:: nomenclature.processor.region.RegionAggregationMapping
    :members:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
     "sphinx_click",
 ]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -103,9 +103,7 @@ intersphinx_mapping = {
 }
 
 # Autodoc configuration
-
 autodoc_typehints = "none"
-
 
 # Prolog for all rst files
 rst_prolog = """

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -102,6 +102,11 @@ intersphinx_mapping = {
     "pyam": ("https://pyam-iamc.readthedocs.io/en/stable/", None),
 }
 
+# Autodoc configuration
+
+autodoc_typehints = "none"
+
+
 # Prolog for all rst files
 rst_prolog = """
 


### PR DESCRIPTION
closes #78.

Addresses the three points raised in #78. 
In addition I also added links to the source code. 

One thing that I found while looking into the type hint issue, is a sphinx add on called "sphinx-autodoc-typehints" (https://github.com/agronholm/sphinx-autodoc-typehints). Right now we are essentially writing the type hints twice, once in the function header and once in the docstring. This add on fixes that by taking the type hints directly from the function header.
Maybe an option for the future. What do you guys think @LauWien and @danielhuppmann?