### PR TITLE
Add setuptools_scm to requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     pydantic
     pyyaml
     jsonschema
+    setuptools_scm
 setup_requires =
     setuptools >= 41
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     pyyaml
     jsonschema
     setuptools_scm
+    pandas
 setup_requires =
     setuptools >= 41
     setuptools_scm


### PR DESCRIPTION
As I recently tried installing nomenclature I saw that `setuptools_scm` is a required dependency that was missing from `setup.cfg`.
It was in there but only under `setup_requires` and since `nomenclature/__init__.py` uses it to get the current version it is an actual dependency.