### PR TITLE
Feature/automate release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,39 @@
+name: Publish to PyPI and TestPyPI
+
+on: push
+  branches:
+    - feature/automate-release
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@v1
+      with:
+        password: ${{ secrets.TESTPYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,4 @@
+# Workflow created according to: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 name: Publish to PyPI and TestPyPI
 
 on: 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,12 +29,12 @@ jobs:
         --wheel
         --outdir dist/
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TESTPYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,9 @@ name: Publish to PyPI and TestPyPI
 
 on: 
   push:
-    branches:
-      - feature/automate-release
+    tags: ["v*"]
+  release:
+    types: [published]
 
 jobs:
   build-n-publish:
@@ -34,7 +35,7 @@ jobs:
         password: ${{ secrets.TESTPYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
+      if: github.event_name == 'release'
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,9 @@
 name: Publish to PyPI and TestPyPI
 
-on: push
-  branches:
-    - feature/automate-release
+on: 
+  push:
+    branches:
+      - feature/automate-release
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
closes #57.

Added the github action to publish to pypi in the event of a release. 
I tested it on my fork with test-pypi. Deployment keys are also added.
I've also linked the repo to Zenodo. For the next release we should get a DOI.