### PR TITLE
Refactor tags to use f-string formatting

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -165,13 +165,13 @@ with ``tag_``.
 
 .. code:: yaml
 
-   - <Tag>:
+   - Tag:
      - Some Key:
          description: a short description of the key
 
-When importing a *tag* codelist, any occurrence of ``<Tag>`` in a variable
+When importing a *tag* codelist, any occurrence of ``{Tag}`` in a variable
 name will be replaced by every element in the Tag dictionary. The
-``<Tag>`` will also be replaced in any of the variable attributes.
+``{Tag}`` will also be replaced in any of the variable attributes.
 
 
 RegionProcessor

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -3,9 +3,6 @@ from typing import Union, List, Dict
 from pydantic import BaseModel, validator
 
 
-TAG_PATTERN = compile("^<.*>$")
-
-
 class Code(BaseModel):
     """A simple class for a mapping of a "code" to its attributes"""
 
@@ -27,18 +24,11 @@ class Code(BaseModel):
 
 
 class Tag(Code):
-    """A simple class for a mapping of a "<tag>" to "target codes" and attributes"""
+    """A simple class for a mapping of a "{tag}" to "target codes" and attributes"""
 
     attributes: List[
         Dict[str, Union[str, Dict[str, Union[str, int, float, bool, List, None]], None]]
     ]
-
-    @validator("name")
-    def validate_tag_format(cls, v):
-        # Note: the pattern is also enforced by json-schema via the tag_schema.yaml
-        if not match(TAG_PATTERN, v):
-            raise ValueError(f"The key is not formatted as a tag (`<..>`): {v}")
-        return v
 
 
 def replace_tags(code_list, tag, tag_dict):
@@ -61,11 +51,11 @@ def _replace_tags(code, tag, target_list):
     _code_list = []
 
     for target in target_list:
-        key = code.name.replace(tag, target.name)
+        key = code.name.replace("{" + tag + "}", target.name)
         attrs = code.attributes.copy()
         for _key, _value in target.attributes.items():
             if _key in attrs:
-                attrs[_key] = attrs[_key].replace(tag, _value)
+                attrs[_key] = attrs[_key].replace("{" + tag + "}", _value)
 
         _code = Code(name=key, attributes=attrs)
         _code_list.append(_code)

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -51,7 +51,7 @@ def _replace_tags(code, tag, target_list):
     _code_list = []
 
     for target in target_list:
-        key = code.name.replace("{" + tag + "}", target.name)
+        key = code.name.replace(f"{{{tag}}}", target.name)
         attrs = code.attributes.copy()
         for _key, _value in target.attributes.items():
             if _key in attrs:

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -55,7 +55,7 @@ def _replace_tags(code, tag, target_list):
         attrs = code.attributes.copy()
         for _key, _value in target.attributes.items():
             if _key in attrs:
-                attrs[_key] = attrs[_key].replace("{" + tag + "}", _value)
+                attrs[_key] = attrs[_key].replace(f"{{{tag}}}", _value)
 
         _code = Code(name=key, attributes=attrs)
         _code_list.append(_code)

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -162,7 +162,7 @@ class CodeList(BaseModel):
             with open(f, "r", encoding="utf-8") as stream:
                 _code_list = yaml.safe_load(stream)
 
-            # check if this file contains a dictionary with <tag>-style keys
+            # check if this file contains a dictionary with {tag}-style keys
             if f.name.startswith("tag_"):
                 # validate against the tag schema
                 validate(_code_list, SCHEMA_MAPPING["tag"])

--- a/nomenclature/validation_schemas/tag_schema.yaml
+++ b/nomenclature/validation_schemas/tag_schema.yaml
@@ -13,9 +13,8 @@ definitions:
   Tag:
     type: object
     patternProperties:
-      # The key of the dictionary is the tag name and must be written as `<Tag>`
-      # Note: the pattern is also enforced by pydantic in the `Tag` class
-      ^<.+>$:
+      # The key of the dictionary is the tag name
+      ^.+$:
         type: array
         items:
           $ref: '#/definitions/TargetDict'
@@ -27,9 +26,9 @@ definitions:
     type: object
     patternProperties:
       # The key of the top-level dictionary is the target name
-      # (replace `<Tag>` by `Target` in the variable code)
+      # (replace `{Tag}` by `Target` in the variable code)
       ^.+$:
-        # Attributes-dictionary (replace `<Tag>` by `value` in the `key` attribute)
+        # Attributes-dictionary (replace `{Tag}` by `value` in the `key` attribute)
         type: object
         additionalProperties:
           type: [string, number, boolean, "null"]

--- a/tests/data/custom_dimension_nc/variable/tag_fuel.yaml
+++ b/tests/data/custom_dimension_nc/variable/tag_fuel.yaml
@@ -1,3 +1,3 @@
-- <Fuel>:
+- Fuel:
   - Coal:
       definition: coal

--- a/tests/data/custom_dimension_nc/variable/variables.yaml
+++ b/tests/data/custom_dimension_nc/variable/variables.yaml
@@ -1,9 +1,9 @@
 - Primary Energy:
     definition: Total primary energy consumption
     unit: EJ/yr
-- Primary Energy|<Fuel>:
-    definition: Primary energy consumption of <Fuel>
+- Primary Energy|{Fuel}:
+    definition: Primary energy consumption of {Fuel}
     unit: EJ/yr
-- Share|<Fuel>:
-    definition: Share of <Fuel> in the total primary energy mix
+- Share|{Fuel}:
+    definition: Share of {Fuel} in the total primary energy mix
     unit:

--- a/tests/data/duplicate_tag_raises/tag_1.yaml
+++ b/tests/data/duplicate_tag_raises/tag_1.yaml
@@ -1,4 +1,4 @@
-- <Tag>:
+- Tag:
   - Energy:
       definition: energy carrier
   - Industry:

--- a/tests/data/duplicate_tag_raises/tag_2.yaml
+++ b/tests/data/duplicate_tag_raises/tag_2.yaml
@@ -1,4 +1,4 @@
-- <Tag>:
+- Tag:
   - Fossil:
       definition: fossil fuels
   - Renewables:

--- a/tests/data/tagged_codelist/foo.yaml
+++ b/tests/data/tagged_codelist/foo.yaml
@@ -1,7 +1,7 @@
-- Final Energy|<Sector>:
-    definition: Final energy consumption in the <Sector> sector
+- Final Energy|{Sector}:
+    definition: Final energy consumption in the {Sector} sector
     unit: EJ
 
-- Final Energy|<Sector>|<Source>:
-    definition: Final energy consumption of <Source> in the <Sector> sector
+- Final Energy|{Sector}|{Source}:
+    definition: Final energy consumption of {Source} in the {Sector} sector
     unit: EJ

--- a/tests/data/tagged_codelist/tag_sector.yaml
+++ b/tests/data/tagged_codelist/tag_sector.yaml
@@ -1,4 +1,4 @@
-- <Sector>:
+- Sector:
   - Energy:
       definition: energy
       value_bool: true

--- a/tests/data/tagged_codelist/tag_source.yaml
+++ b/tests/data/tagged_codelist/tag_source.yaml
@@ -1,4 +1,4 @@
-- <Source>:
+- Source:
   - Fossil:
       definition: fossil fuels
   - Renewables:

--- a/tests/data/validation_nc/variable/tag_fuel.yaml
+++ b/tests/data/validation_nc/variable/tag_fuel.yaml
@@ -1,3 +1,3 @@
-- <Fuel>:
+- Fuel:
   - Coal:
       definition: coal

--- a/tests/data/validation_nc/variable/variables.yaml
+++ b/tests/data/validation_nc/variable/variables.yaml
@@ -1,9 +1,9 @@
 - Primary Energy:
     definition: Total primary energy consumption
     unit: EJ/yr
-- Primary Energy|<Fuel>:
-    definition: Primary energy consumption of <Fuel>
+- Primary Energy|{Fuel}:
+    definition: Primary energy consumption of {Fuel}
     unit: EJ/yr
-- Share|<Fuel>:
-    definition: Share of <Fuel> in the total primary energy mix
+- Share|{Fuel}:
+    definition: Share of {Fuel} in the total primary energy mix
     unit:

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -23,7 +23,7 @@ def test_duplicate_code_raises():
 
 def test_duplicate_tag_raises():
     """Check that code conflicts across different files raises"""
-    match = "Duplicate item in tag codelist: <Tag>"
+    match = "Duplicate item in tag codelist: Tag"
     with pytest.raises(DuplicateCodeError, match=match):
         CodeList.from_directory("variable", TEST_DATA_DIR / "duplicate_tag_raises")
 


### PR DESCRIPTION
This PR changes the use of the tag feature to use a format similar to f-strings instead of the custom `<..>` style.

It is not possible to have keys of the format `{Tag}` (starting with a curly bracket) in a yaml-dictionary file, therefore the structure of the yaml files is changed such that only the tag name is the key (without curly brackets).

closes #88 