### PR TITLE
Add a quickfix for conflict between codes and tags

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -37,7 +37,7 @@ def replace_tags(code_list, tag, tag_dict):
     _code_list = []
 
     for code in code_list:
-        if tag in code.name:
+        if f"{{{tag}}}" in code.name:
             _code_list.extend(_replace_tags(code, tag, tag_dict))
         else:
             _code_list.append(code)

--- a/tests/data/tagged_codelist/foo.yaml
+++ b/tests/data/tagged_codelist/foo.yaml
@@ -1,3 +1,8 @@
+- Final Energy|Sector:
+    # the "Sector" guards against feature regression (conflict with "Sector" tag)
+    definition: Final energy consumption in the Sector
+    unit: EJ
+
 - Final Energy|{Sector}:
     definition: Final energy consumption in the {Sector} sector
     unit: EJ


### PR DESCRIPTION
PR #91 introduced a bug: if a code (variable name) contains the name of a tag (e.g., the tag "Industry" and the variable "Final Energy|Industry"), then the variable was added multiple times during the replace-tag phase, causing a duplicate-code error.