### PR TITLE
Collect errors during reading of region 

### DIFF
--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -168,16 +168,16 @@ def test_region_processor_wrong_args():
 
 def test_region_processor_multiple_wrong_mappings():
     # Read in the entire region_aggregation directory and return **all** errors
-    errors = ".*\\n.*\\n.*".join(
+    errors = r".*\n.*\n.*".join(
         [
             "7 validation errors for RegionProcessor",
-            "Name collision.*common_region_1.*illegal_mapping_duplicate_common.yaml",
-            "Additional properties.*something_extra.*_illegal_attribute.yaml",
-            "native and common.*common_region_1.*conflict_regions.yaml",
-            "At least one of the two.*model_only.yaml",
-            "common_region_1.*region_a.*not.*array.*invalid_format_dict.yaml",
-            "Name collision.*alternative_name_a.*duplicate_native_rename.yaml",
-            "Name collision.*alternative_name_a.*duplicate_native.yaml",
+            "Name collision.*common_region_1.*illegal_mapping_duplicate_common",
+            "Additional properties.*something_extra.*_illegal_attribute",
+            "native and common.*common_region_1.*conflict_regions",
+            "At least one of the two.*model_only",
+            "common_region_1.*region_a.*not.*array.*invalid_format_dict",
+            "Name collision.*alternative_name_a.*duplicate_native_rename",
+            "Name collision.*alternative_name_a.*duplicate_native",
         ]
     )
 

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -168,9 +168,9 @@ def test_region_processor_wrong_args():
 
 def test_region_processor_multiple_wrong_mappings():
     # Read in the entire region_aggregation directory and return **all** errors
-    errors = ".*\n.*\n.*".join(
+    errors = ".*\\n.*\\n.*".join(
         [
-            ".*7 validation errors for RegionProcessor",
+            "7 validation errors for RegionProcessor",
             "Name collision.*common_region_1.*illegal_mapping_duplicate_common.yaml",
             "Additional properties.*something_extra.*_illegal_attribute.yaml",
             "native and common.*common_region_1.*conflict_regions.yaml",

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -168,18 +168,7 @@ def test_region_processor_wrong_args():
 
 def test_region_processor_multiple_wrong_mappings():
     # Read in the entire region_aggregation directory and return **all** errors
-    errors = r".*\n.*\n.*".join(
-        [
-            "7 validation errors for RegionProcessor",
-            "Name collision.*common_region_1.*illegal_mapping_duplicate_common",
-            "Additional properties.*something_extra.*_illegal_attribute",
-            "native and common.*common_region_1.*conflict_regions",
-            "At least one of the two.*model_only",
-            "common_region_1.*region_a.*not.*array.*invalid_format_dict",
-            "Name collision.*alternative_name_a.*duplicate_native_rename",
-            "Name collision.*alternative_name_a.*duplicate_native",
-        ]
-    )
+    msg = "7 validation errors for RegionProcessor"
 
-    with pytest.raises(pydantic.ValidationError, match=errors):
+    with pytest.raises(pydantic.ValidationError, match=msg):
         RegionProcessor.from_directory(TEST_DATA_DIR / "region_aggregation")

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -145,7 +145,7 @@ def test_region_processor_not_defined(simple_definition):
 
 def test_region_processor_duplicate_model_mapping():
     error_msg = ".*model_a.*mapping_(1|2).yaml.*mapping_(1|2).yaml"
-    with pytest.raises(ModelMappingCollisionError, match=error_msg):
+    with pytest.raises(pydantic.ValidationError, match=error_msg):
         RegionProcessor.from_directory(TEST_DATA_DIR / "regionprocessor_duplicate")
 
 
@@ -164,3 +164,22 @@ def test_region_processor_wrong_args():
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_working/mapping_1.yaml"
         )
+
+
+def test_region_processor_multiple_wrong_mappings():
+    # Read in the entire region_aggregation directory and return **all** errors
+    errors = ".*\n.*\n.*".join(
+        [
+            ".*7 validation errors for RegionProcessor",
+            "Name collision.*common_region_1.*illegal_mapping_duplicate_common.yaml",
+            "Additional properties.*something_extra.*_illegal_attribute.yaml",
+            "native and common.*common_region_1.*conflict_regions.yaml",
+            "At least one of the two.*model_only.yaml",
+            "common_region_1.*region_a.*not.*array.*invalid_format_dict.yaml",
+            "Name collision.*alternative_name_a.*duplicate_native_rename.yaml",
+            "Name collision.*alternative_name_a.*duplicate_native.yaml",
+        ]
+    )
+
+    with pytest.raises(pydantic.ValidationError, match=errors):
+        RegionProcessor.from_directory(TEST_DATA_DIR / "region_aggregation")


### PR DESCRIPTION
As the recent PR in the navigate workflow has shown it would be very convenient to get all errors related to region mappings in one single go instead of getting one, fixing one and running `RegionProcessor.from_directory()` over and over again.

This PR addresses that, errors during reading are collected and returned as a single `pydantic.Validation` error that contains all individual errors. This way mappings can be fixed much faster.

I added a test `test_region_processor_multiple_wrong_mappings` which reads in a total of 8 mappings, 7 of which cause errors.