### PR TITLE
Silence logger during region processing

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -315,13 +315,13 @@ class RegionProcessor(BaseModel):
 
             # If no mapping is defined the data frame is returned unchanged
             if model not in self.mappings:
-                logging.info(f"No region aggregation mapping found for model {model}")
+                logger.info(f"No region aggregation mapping found for model {model}")
                 processed_dfs.append(model_df)
             # Otherwise we first rename, then aggregate
             else:
                 # before aggregating, check that all regions are valid
                 self.mappings[model].validate_regions(dsd)
-                logging.info(
+                logger.info(
                     f"Applying region aggregation mapping for model {model} from file "
                     f"{self.mappings[model].file}"
                 )

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -327,7 +327,7 @@ class RegionProcessor(BaseModel):
                     f"{self.mappings[model].file}"
                 )
 
-                with adjust_log_level():  # silence empty filter
+                with adjust_log_level(level="ERROR"):  # silence empty filter
                     # Rename
                     if self.mappings[model].native_regions is not None:
                         processed_dfs.append(

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -349,7 +349,7 @@ class RegionProcessor(BaseModel):
                         }
                         for cr in self.mappings[model].common_regions:
                             regions = [cr.name, cr.constituent_regions]
-                            # First perform 'simple' aggregation (i.e. no aggregation args)
+                            # First, perform 'simple' aggregation (no arguments)
                             processed_dfs.append(
                                 model_df.aggregate_region(vars_default_args, *regions)
                             )
@@ -357,16 +357,16 @@ class RegionProcessor(BaseModel):
                             for var, kwargs in vars_kwargs.items():
                                 if "region-aggregation" not in kwargs:
                                     processed_dfs.append(
-                                        model_df.aggregate_region(var, *regions, **kwargs)
+                                        model_df.aggregate_region(
+                                            var, *regions, **kwargs
+                                        )
                                     )
                                 else:
                                     for rename_var in kwargs["region-aggregation"]:
                                         for _rename, _kwargs in rename_var.items():
                                             processed_dfs.append(
                                                 model_df.aggregate_region(
-                                                    var,
-                                                    *regions,
-                                                    **_kwargs,
+                                                    var, *regions, **_kwargs
                                                 ).rename(variable={var: _rename})
                                             )
 


### PR DESCRIPTION
When working on the navigate-refactoring, I noticed that calling region-processing on non-existing regions or (lists of) variables prints 
```
pyam.utils - WARNING: Formatted data is empty!
```
quite a few times to the log, with no actually helpful information.

This PR uses the pyam `adjust_log_level()` function to silence the pyam-logger for that part of the code.