### PR TITLE
Add a `CodeList.to_excel` method

### DIFF
--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -1,5 +1,7 @@
 import pytest
 from pydantic import ValidationError
+import pandas as pd
+import pandas.testing as pdt
 from nomenclature import CodeList
 from nomenclature.error.codelist import DuplicateCodeError
 
@@ -48,3 +50,19 @@ def test_region_codelist():
     assert "Some Country" in code
     assert code["Some Country"]["hierarchy"] == "countries"
     assert code["Some Country"]["iso2"] == "XY"
+
+
+def test_to_excel(tmpdir):
+    """Check writing to xlsx"""
+    file = tmpdir / "foo.xlsx"
+
+    (
+        CodeList.from_directory(
+            "Variable", TEST_DATA_DIR / "validation_nc" / "variable"
+        ).to_excel(file)
+    )
+
+    obs = pd.read_excel(file)
+    exp = pd.read_excel(TEST_DATA_DIR / "validation_nc.xlsx")
+
+    pdt.assert_frame_equal(obs, exp)


### PR DESCRIPTION
# Overview

This PR adds a method (and test) to write the items from a CodeList to an xlsx spreadsheet.

# Usage

If a user has cloned the project-specifications repository from Github, she can use the following to translate a dimension e.g., the list of *variables*, to an excel spreadsheet.

```python
from pathlib import Path
from nomenclature import CodeList

CodeList.from_directory("Variable", Path("definitions/variable")).to_excel(<file>)
```

where *file* is the (folder and) name of the target file.
 