### PR TITLE
Quickfix for region-aggregation with missing weights

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -347,6 +347,7 @@ class RegionProcessor(BaseModel):
                         vars_default_args = [
                             var for var, kwargs in vars.items() if not kwargs
                         ]
+                        # TODO skip if required weight does not exist
                         vars_kwargs = {
                             var: kwargs
                             for var, kwargs in vars.items()

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -387,10 +387,12 @@ class RegionProcessor(BaseModel):
                                                     _df.rename(variable={var: _rename})
                                                 )
 
-        if processed_dfs:
-            return pyam.concat(processed_dfs)
-        else:
-            return IamDataFrame(pd.DataFrame([], columns=df.dimensions + ["value"]))
+        if not processed_dfs:
+            raise ValueError(
+                f"The region aggregation for model {model} resulted in an empty dataset"
+            )
+
+        return pyam.concat(processed_dfs)
 
     def _filter_dict_args(
         self, variables, dsd: DataStructureDefinition, keys: Set[str] = AGG_KWARGS

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -3,7 +3,6 @@ from collections import Counter
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
-import pandas as pd
 import pyam
 import pydantic
 import yaml

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,6 +167,7 @@ def test_region_processing_complete(directory):
             None,
         ),
         # check that region-aggregation with missing weights passes (inconsistent index)
+        # TODO check the log output
         (
             "weighted_aggregation",
             [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,6 +47,30 @@ def test_region_processing_rename():
     assert_iamframe_equal(obs, exp)
 
 
+def test_region_processing_rename_empty():
+    # Test that renaming when region does not exist returns empty
+    # see also https://github.com/IAMconsortium/pyam/issues/631
+
+    test_df = IamDataFrame(
+        pd.DataFrame(
+            [
+                ["model_a", "scen_a", "region_foo", "Primary Energy", "EJ/yr", 1, 2],
+            ],
+            columns=IAMC_IDX + [2005, 2010],
+        )
+    )
+
+    obs = process(
+        test_df,
+        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+        processor=RegionProcessor.from_directory(
+            TEST_DATA_DIR / "region_processing/rename_only"
+        ),
+    )
+
+    assert obs.empty
+
+
 def test_region_processing_no_mapping(simple_df):
     # Test that a model without a mapping is passed untouched
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,8 +47,8 @@ def test_region_processing_rename():
     assert_iamframe_equal(obs, exp)
 
 
-def test_region_processing_rename_empty():
-    # Test that renaming when region does not exist returns empty
+def test_region_processing_empty_raises():
+    # Test that an empty result of the region-processing raises
     # see also https://github.com/IAMconsortium/pyam/issues/631
 
     test_df = IamDataFrame(
@@ -60,15 +60,14 @@ def test_region_processing_rename_empty():
         )
     )
 
-    obs = process(
-        test_df,
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
-        processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/rename_only"
-        ),
-    )
-
-    assert obs.empty
+    with pytest.raises(ValueError, match="The region aggregation for model model_a"):
+        obs = process(
+            test_df,
+            DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+            processor=RegionProcessor.from_directory(
+                TEST_DATA_DIR / "region_processing/rename_only"
+            ),
+        )
 
 
 def test_region_processing_no_mapping(simple_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,7 +61,7 @@ def test_region_processing_empty_raises():
     )
 
     with pytest.raises(ValueError, match="The region aggregation for model model_a"):
-        obs = process(
+        process(
             test_df,
             DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
             processor=RegionProcessor.from_directory(


### PR DESCRIPTION
This PR is a first quickfix for #87. Added to-do notes for a better separation between "weight does not exist at all" versus "weight exists but index is inconsistent".

Because in a related section of the code and urgent, I also added a quickfix for https://github.com/IAMconsortium/pyam/issues/631 directly to this PR. Renaming an empty IamDataFrame raises an unintended error, so I separated the aggregation-and-rename into separate steps with an if in-between.

FYI @HauHe @Renato-Rodrigues