### PR TITLE
Check if region-processing results are empty

### DIFF
--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import yaml
 import logging
 from pathlib import Path
 

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -345,8 +345,9 @@ class RegionProcessor(BaseModel):
         Raises
         ------
         ValueError
-            In case there are regions present in the input data which are not mentioned
-            in the corresponding model mapping.
+            * In case there are regions present in the input data which are not
+              mentioned in the corresponding model mapping.
+            * In case the region-processing results in an empty data frame.
         """
         processed_dfs: List[IamDataFrame] = []
         for model in df.model:
@@ -438,7 +439,8 @@ class RegionProcessor(BaseModel):
                     elif not common_region_df.empty:
                         processed_dfs.append(common_region_df)
 
-        if not processed_dfs:
+        # raise an error if processed_dfs has no entries or all are empty
+        if not processed_dfs or all(df.empty for df in processed_dfs):
             raise ValueError(
                 f"The region-processing for model(s) {df.model} returned an empty "
                 "dataset"

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -345,9 +345,8 @@ class RegionProcessor(BaseModel):
         Raises
         ------
         ValueError
-            * In case there are regions present in the input data which are not
-              mentioned in the corresponding model mapping.
-            * In case the region-processing results in an empty data frame.
+            * If *df* contains regions that are not listed in the model mapping, or
+            * If the region-processing results in an empty **IamDataFrame**.
         """
         processed_dfs: List[IamDataFrame] = []
         for model in df.model:

--- a/tests/data/region_processing/empty_aggregation/model_a.yaml
+++ b/tests/data/region_processing/empty_aggregation/model_a.yaml
@@ -1,0 +1,7 @@
+model: model_a
+common_regions:
+  - region_A: 
+    - region_a
+exclude_regions:
+  - region_C
+  - region_foo

--- a/tests/data/region_processing/empty_aggregation/model_b.yaml
+++ b/tests/data/region_processing/empty_aggregation/model_b.yaml
@@ -1,0 +1,8 @@
+model: model_b
+common_regions:
+  - region_A:
+    - region_a
+  - region_B:
+    - region_b
+exclude_regions:
+  - region_foo

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,7 +47,10 @@ def test_region_processing_rename():
     assert_iamframe_equal(obs, exp)
 
 
-def test_region_processing_empty_raises():
+@pytest.mark.parametrize(
+    "rp_dir", ["region_processing/rename_only", "region_processing/empty_aggregation"]
+)
+def test_region_processing_empty_raises(rp_dir):
     # Test that an empty result of the region-processing raises
     # see also https://github.com/IAMconsortium/pyam/issues/631
 
@@ -64,9 +67,7 @@ def test_region_processing_empty_raises():
         process(
             test_df,
             DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
-            processor=RegionProcessor.from_directory(
-                TEST_DATA_DIR / "region_processing/rename_only"
-            ),
+            processor=RegionProcessor.from_directory(TEST_DATA_DIR / rp_dir),
         )
 
 

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -185,7 +185,10 @@ def test_region_processor_exclude_model_native_overlap_raises():
 
     with pytest.raises(
         pydantic.ValidationError,
-        match="'region_a'.* 'native_regions'.*\n.*\n.*'region_a'.*'common_regions'",
+        match=(
+            "'region_a'.* ['native_regions'|'common_regions'].*\n.*\n.*'region_a'.*"
+            "['native_regions'|'common_regions']"
+        ),
     ):
         RegionProcessor.from_directory(
             TEST_DATA_DIR / "regionprocessor_exclude_region_overlap"


### PR DESCRIPTION
closes #112.

## New feature

Previously at the end of `Regionprocessor.apply` there was a check if the resulting list of `pyam.IamDataFrame` objects `processed_dfs` was non-empty. If it was in fact empty, an error is raised.
The PR now adds a explicit check to see if `processed_dfs` actually contains any non-empty `IamDataFrames`. In case they are all empty, the same error is raised. 
