### PR TITLE
Rewrite the user-guide page for local usage

### DIFF
--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -38,8 +38,7 @@ define the renaming of native regions and aggregation to common regions.
 
 The top-level function :func:`process` takes both of the above classes as input along
 with data in form of a :class:`pyam.IamDataFrame`. The input data is aggregated using
-the RegionProcessor and validated using DataStructureDefinition. Details are covered in
-:ref:`minimum_working_example`. 
+the RegionProcessor and validated using DataStructureDefinition.
 
 .. toctree::
   :maxdepth: 3
@@ -47,4 +46,4 @@ the RegionProcessor and validated using DataStructureDefinition. Details are cov
   user_guide/directory-structure
   user_guide/codelist
   user_guide/model-mapping
-  user_guide/code-example
+  user_guide/local-usage

--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -181,10 +181,6 @@ and 'variable' (e.g. 'scenario' or 'model'), the requirements for are more simpl
 
    dsd = DataStructureDefinition('definitions', ['region', 'variable', 'scenario'])
 
-  
-More details on how to instantiate a DataStructureDefinition can be found in
-:ref:`minimum_working_example`.
-
 Tag
 ^^^
 

--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -232,4 +232,4 @@ dimensions. In the above example using ``dsd.validate(df, ['scenario'])`` would 
 
 In practice, ``DataStructureDefinition.validate`` is usually not called directly but
 rather as part of the :func:`process` function which combines validation and region
-processing. Refer to the :ref:`minimum_working_example` for details.
+processing.

--- a/doc/source/user_guide/local-usage.rst
+++ b/doc/source/user_guide/local-usage.rst
@@ -3,8 +3,8 @@
 Local usage of a project
 ========================
 
-This section aims to provide a minimum working example of how to use the nomenclature
-package.
+.. attention:: This page is intended for users who are familiar with Python and
+    `git <https://git-scm.com>`_ (or a service like `GitHub <https://github.com>`_).
 
 It is assumed that the variable templates and model mappings already exist. Details on
 how those are structured and how to start using nomenclature "from scratch" can be found

--- a/doc/source/user_guide/local-usage.rst
+++ b/doc/source/user_guide/local-usage.rst
@@ -49,7 +49,7 @@ the validation was successful. Otherwise, it will raise an error with details.
   # Read the data using pyam
   df = pyam.IamDataFrame("/path/to/file")
 
-  # Perform the validation and apply the region aggregation
+  # Perform the validation
   df = process(df, dsd)
 
 Validation and region processing

--- a/doc/source/user_guide/local-usage.rst
+++ b/doc/source/user_guide/local-usage.rst
@@ -1,16 +1,63 @@
 .. _local_usage:
 
+.. currentmodule:: nomenclature
+
 Local usage of a project
 ========================
 
 .. attention:: This page is intended for users who are familiar with Python and
     `git <https://git-scm.com>`_ (or a service like `GitHub <https://github.com>`_).
 
-It is assumed that the variable templates and model mappings already exist. Details on
-how those are structured and how to start using nomenclature "from scratch" can be found
-in :ref:`codelist` and :ref:`model_mapping` respectively. 
+You can use the **nomenclature** package locally (on your machine) for validation
+and region-aggregration. This can be helpful as part of processing your model results,
+or to ensure that a submission to an IIASA Scenario Explorer instance will succeed.
 
-The following outlines how to use the nomenclature package:
+Requirements
+------------
+
+1. Install the **nomenclature** package (see the :ref:`installation` instructions)
+2. Have a project folder that has the required :ref:`dir_structure`:
+
+   * Set up the folder with the required structure and files yourself, or
+   * Clone the git repository for a specific project
+     (e.g., `openENTRANCE <https://github.com/openENTRANCE/openentrance>`_)
+
+   .. attention:: When using a project repository from GitHub or a similar service,
+          make sure that you keep your local clone in sync with the upstream repository.
+
+Usage options
+-------------
+
+Validation against the codelists
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The easiest use case is to validate that a data file or an :class:`IamDataFrame <pyam.IamDataFrame>`
+is compatible with the codelists (lists of variables and regions) of a project's
+:class:`DataStructureDefinition`.
+
+If the :func:`process` function returns an :class:`IamDataFrame <pyam.IamDataFrame>`,
+the validation was successful. Otherwise, it will raise an error with details.
+
+.. code-block:: python
+
+  import pyam
+  from nomenclature import DataStructureDefinition, process
+
+  # Initialize the DataStructureDefinition from a suitable directory
+  dsd = DataStructureDefinition("definitions")
+
+  # Read the data using pyam
+  df = pyam.IamDataFrame("/path/to/file")
+
+  # Perform the validation and apply the region aggregation
+  df = process(df, dsd)
+
+Validation and region processing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A more elaborate use case is to perform validation against the codelists and use the
+:class:`RegionProcessor` to aggregate timeseries from "native regions" of a model to
+"common regions" (i.e., regions that are used for scenario comparison in a project).
 
 .. code-block:: python
 
@@ -18,7 +65,7 @@ The following outlines how to use the nomenclature package:
   import pyam
   from nomenclature import DataStructureDefinition, RegionProcessor, process
   
-  # Initialize DataStructureDefinition from a suitable directory
+  # Initialize a DataStructureDefinition from a suitable directory
   dsd = DataStructureDefinition("definitions")
   
   # Initialize a RegionProcessor from a suitable directory that has the mappings
@@ -30,16 +77,19 @@ The following outlines how to use the nomenclature package:
   # Perform the validation and apply the region aggregation
   df = process(df, dsd, processor=rp)
 
-* The function :func:`process` takes a :class:`pyam.IamDataFrame` as input.
+Using a project-specific workflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* :class:`DataStructureDefinition` and :class:`RegionProcessor` are initialized from
-  directories containing yaml files. See :ref:`dir_structure` for details.
+Several projects specify custom workflows that combine validation and region-processing
+with other validation steps or post-processing modules. These workflows are usually
+implemented as a ``main()`` function in ``workflow.py`` of a project repository.
 
-* The processor argument of :func:`process` is optional and may only to be used if there
-  are model mappings. See :ref:`toplevel_functions` for details.
+.. code-block:: python
 
-* Per default :class:`DataStructureDefinition` will search for a ``variable/`` and a
-  ``region/`` directory with the corresponding codelists to validate those two
-  dimensions. If any another list of dimensions should be validated instead, the
-  *dimensions* argument which is a list of strings can be provided. See
-  :ref:`toplevel_functions` for details.
+  # Import the pyam library and the project-specific workflow
+  import pyam
+  from workflow import main as project_workflow
+
+  # Read the scenario data and call the project-specific workflow
+  df = pyam.IamDataFrame("/path/to/file")
+  df = project_workflow(df)

--- a/doc/source/user_guide/local-usage.rst
+++ b/doc/source/user_guide/local-usage.rst
@@ -1,7 +1,7 @@
-.. _minimum_working_example:
+.. _local_usage:
 
-Minimum working example
-=======================
+Local usage of a project
+========================
 
 This section aims to provide a minimum working example of how to use the nomenclature
 package.

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -141,5 +141,4 @@ DataStructureDefinition *must* contain the *region* and *variable* dimensions in
 
 In practice, normally, both region processing *and* validation are desired and so the
 use of the :func:`process` function is recommended over calling
-``RegionProcessor.apply()`` directly. Details can be found in the
-:ref:`minimum_working_example`.
+``RegionProcessor.apply()`` directly.


### PR DESCRIPTION
This PR changes the user-guide page "Minimum Working Example" to a "Local Usage" page that clearly specifies:
- what are the knowledge requirements to make use of this?
- why is this useful?
- how to get project-specific definitions and mappings?
- how to run a (non-installable) project-specific workflow?

The docs from this branch are rendered [here](https://nomenclature-iamc.readthedocs.io/en/docs-local-usage/user_guide/local-usage.html).