### PR TITLE
Rewrite the overview section on the docs index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nomenclature - Working with IAMC-style data templates
+# nomenclature - Working with IAMC-format project templates
 
 Copyright 2021-2022 IIASA
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,24 @@ black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://gith
 
 ## Overview
 
-This package facilitates working with data templates that follow the format developed by
-the [Integrated Assessment Modeling Consortium (IAMC)](https://www.iamconsortium.org).
-It supports validation of scenario data and region processing, which consists of
-renaming and aggregation of model "native regions" to "common regions" used in a
-project.
+The **nomenclature** package facilitates validation and processing of scenario data
+for model comparison projects and scenario analysis. It allows to manage
+project templates and "codelists" that follow the format developed by the
+[Integrated Assessment Modeling Consortium (IAMC)](https://www.iamconsortium.org)..
 
+A "codelist" is a list allowed values (or "codes") for dimensions of IAMC-format data,
+typically *regions* and *variables*. Each code can have additional attributes:
+for example, a "variable" (string) usually has a definition and an expected unit.
+Read the [SDMX Guidelines](https://sdmx.org/?page_id=4345) for more information on
+the concept of codelists.
+
+The **nomenclature** package supports three main use cases:
+
+- Management of codelists, definitions and mappings for model comparison projects
+- Validation of scenario data against the codelists of a specific project
+- Region-processing (aggregation and renaming) from "native regions" of a model to
+  "common regions" (i.e., regions that are used for scenario comparison in a project).
+  
 The full documentation is hosted on [Read the
 Docs](https://nomenclature-iamc.readthedocs.io/)
 

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,4 +1,6 @@
-div.body h1 {font-size: 175%}
+div.body h1 {font-size: 160%}
+div.body h2 {font-size: 140%}
+div.body h3 {font-size: 120%}
 
 div.admonition p.admonition-title {
     font-size: 17px;

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,7 +23,7 @@ Release v\ |version|.
    :target: https://nomenclature-iamc.readthedocs.io
 
 Overview
-========
+--------
 
 The nomenclature package facilitates working with "codelists" that follow the format
 developed by the `Integrated Assessment Modeling Consortium (IAMC)
@@ -50,10 +50,10 @@ The complete user guide including the file specifications for codelists and mode
 mappings, example code and details on how to use nomenclature is given in "User Guide".
 
 Table of Contents
-=================
+-----------------
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
 
    installation
    user_guide
@@ -61,7 +61,7 @@ Table of Contents
    cli
 
 Acknowledgement
-===============
+---------------
 
 .. figure:: _static/open_entrance-logo.png
    :align: right

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,16 +5,19 @@
 
 Release v\ |version|.
 
-|license| |python| |black| |pytest| |rtd|
+|license| |doi| |python| |black| |pytest| |rtd|
 
 .. |license| image:: https://img.shields.io/badge/License-Apache%202.0-black
    :target: https://github.com/IAMconsortium/nomenclature/blob/main/LICENSE
 
-.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
+.. |doi| image:: https://zenodo.org/badge/375724610.svg
+   :target: https://zenodo.org/badge/latestdoi/375724610
 
 .. |python| image:: https://img.shields.io/badge/python-_3.8_|_3.9_|_3.10-blue?logo=python&logoColor=white
    :target: https://github.com/IAMconsortium/nomenclature
+
+.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
 
 .. |pytest| image:: https://github.com/IAMconsortium/nomenclature/actions/workflows/pytest.yml/badge.svg
    :target: https://github.com/IAMconsortium/nomenclature/actions/workflows/pytest.yml

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: nomenclature
 
-**nomenclature**: Working with IAMC-style scenario data
-=======================================================
+**nomenclature**: Working with IAMC-style project templates
+===========================================================
 
 Release v\ |version|.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,6 @@
 .. currentmodule:: nomenclature
 
-**nomenclature**: Working with IAMC-style project templates
+**nomenclature**: Working with IAMC-format project templates
 ===========================================================
 
 Release v\ |version|.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,29 +28,26 @@ Release v\ |version|.
 Overview
 --------
 
-The nomenclature package facilitates working with "codelists" that follow the format
-developed by the `Integrated Assessment Modeling Consortium (IAMC)
-<https://www.iamconsortium.org>`_. Codelists are yaml file based lists of allowed values
-(or codes) for dimensions of IAMC-style data, for example *regions* and *variables*.
-Using these codelists, nomenclature performs data validation to check if a provided data
-set conforms to the values in the code lists. 
+The **nomenclature** package facilitates validation and processing of scenario data
+for model comparison projects and scenario analysis. It allows to manage
+project templates and "codelists" that follow the format developed by the
+`Integrated Assessment Modeling Consortium (IAMC) <https://www.iamconsortium.org>`_.
 
-Additionally, it can execute "region processing", which consists of renaming of "native
-regions" and/or aggregation to "common regions" used in a project.
+A "codelist" is a list allowed values (or "codes") for dimensions of IAMC-format data,
+typically *regions* and *variables*. Each code can have additional attributes:
+for example, a "variable" (string) usually has a definition and an expected unit.
+Read the `SDMX Guidelines <https://sdmx.org/?page_id=4345>`_ for more information on
+the concept of codelists.
 
-Those two tasks are carried out by two classes:
+The **nomenclature** package supports three main use cases:
 
-#. The :class:`DataStructureDefinition` class handles the validation of scenario data.
-   It contains data templates for *variables* (including units) and *regions* to be used
-   in a model comparison or scenario exercise following the IAMC data format.
+- Management of codelists, definitions and mappings for model comparison projects
+- Validation of scenario data against the codelists of a specific project
+- Region-processing (aggregation and renaming) from "native regions" of a model to
+  "common regions" (i.e., regions that are used for scenario comparison in a project).
 
-#. The :class:`RegionProcessor` class carries out renaming and aggregation based on
-   information given in yaml model mapping files.
-
-Instructions on how to install nomenclature can be found in the "Installation" section.
-
-The complete user guide including the file specifications for codelists and model
-mappings, example code and details on how to use nomenclature is given in "User Guide".
+The codelists, definitions and mappings are stored as yaml files.
+Refer to the :ref:`user_guide` for more information.
 
 Table of Contents
 -----------------


### PR DESCRIPTION
This PR rewrites the index page of the docs as well as the Readme to give a higher-level summary of the package scope and aims, to reduce duplication with the User Guide section (which will be tackled as a separate PR).