### PR TITLE
Rewrite the pyam-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ the IPCC and in many model comparison projects at the global and national level,
 including several Horizon 2020 & Horizon Europe projects.
 
 The validation and processing features of the **nomenclature** package
-work with scenario data in the form of a [**pyam.IamDataFrame**](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html)
-object as input.
+work with scenario data as a [**pyam.IamDataFrame**](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html) object.
 
 [Read the **pyam** Docs](https://pyam-iamc.readthedocs.io) for more information!
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ including several Horizon 2020 & Horizon Europe projects.
 
 The validation and processing features of the **nomenclature** package
 work with scenario data in the form of a [**pyam.IamDataFrame**](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html)
-class as input.
+object as input.
 
 [Read the **pyam** Docs](https://pyam-iamc.readthedocs.io) for more information!
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ The **nomenclature** package supports three main use cases:
 - Region-processing (aggregation and renaming) from "native regions" of a model to
   "common regions" (i.e., regions that are used for scenario comparison in a project).
   
-The full documentation is hosted on [Read the
-Docs](https://nomenclature-iamc.readthedocs.io/)
+The documentation is hosted on [Read the Docs](https://nomenclature-iamc.readthedocs.io/).
 
 ## The pyam package
 
@@ -78,7 +77,7 @@ openENTRANCE](https://openentrance.eu) project, which aims to  develop, use and
 disseminate an open, transparent and integrated  modelling platform for assessing
 low-carbon transition pathways in Europe.
 
-Refer to the [openENTRANCE/nomenclature](https://github.com/openENTRANCE/nomenclature)
+Refer to the [openENTRANCE/openentrance](https://github.com/openENTRANCE/openentrance)
 repository for more information.
 
 <img src="./doc/source/_static/EU-logo-300x201.jpg" width="80" height="54" align="left"

--- a/README.md
+++ b/README.md
@@ -36,19 +36,23 @@ The **nomenclature** package supports three main use cases:
   
 The documentation is hosted on [Read the Docs](https://nomenclature-iamc.readthedocs.io/).
 
-## The pyam package
+## Integration with the pyam package
 
 <img src="https://github.com/IAMconsortium/pyam/blob/main/doc/logos/pyam-logo.png"
 width="133" height="100" align="right" alt="pyam logo" />
 
-This package is intended to complement the Python package **pyam**, an open-source
-community toolbox for analysis & visualization of scenario data. That package was
-developed to facilitate working with timeseries scenario data conforming to the format
-developed by the IAMC. It is used in ongoing assessments by the IPCC and in many model
-comparison projects at the global and national level, including several Horizon 2020
-projects.
+The **nomenclature** package is designed to complement the Python package **pyam**,
+an open-source community toolbox for analysis & visualization of scenario data.
+The **pyam** package was developed to facilitate working with timeseries scenario data
+conforming to the format developed by the IAMC. It is used in ongoing assessments by
+the IPCC and in many model comparison projects at the global and national level,
+including several Horizon 2020 & Horizon Europe projects.
 
-[Read the Docs](https://pyam-iamc.readthedocs.io) for more information!
+The validation and processing features of the **nomenclature** package
+work with scenario data in the form of a [**pyam.IamDataFrame**](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html)
+class as input.
+
+[Read the **pyam** Docs](https://pyam-iamc.readthedocs.io) for more information!
 
 ## Getting started
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -77,7 +77,7 @@ the IPCC and in many model comparison projects at the global and national level,
 including several Horizon 2020 & Horizon Europe projects.
 
 The validation and processing features of the **nomenclature** package
-work with scenario data in the form of a pyam.IamDataFrame_ class.
+work with scenario data as a pyam.IamDataFrame_ object.
 
 `Read the Docs <https://pyam-iamc.readthedocs.io>`_ for more information!
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -61,6 +61,28 @@ Table of Contents
    api
    cli
 
+Integration with the **pyam** package
+-------------------------------------
+
+.. image:: https://raw.githubusercontent.com/IAMconsortium/pyam/main/doc/logos/pyam-header.png
+   :width: 320px
+   :align: right
+   :target: https://pyam-iamc.readthedocs.io
+
+The **nomenclature** package is designed to complement the Python package **pyam**,
+an open-source community toolbox for analysis & visualization of scenario data.
+The **pyam** package was developed to facilitate working with timeseries scenario data
+conforming to the format developed by the IAMC. It is used in ongoing assessments by
+the IPCC and in many model comparison projects at the global and national level,
+including several Horizon 2020 & Horizon Europe projects.
+
+The validation and processing features of the **nomenclature** package
+work with scenario data in the form of a pyam.IamDataFrame_ class.
+
+`Read the Docs <https://pyam-iamc.readthedocs.io>`_ for more information!
+
+.. _pyam.IamDataFrame : https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html
+
 Acknowledgement
 ---------------
 


### PR DESCRIPTION
This PR rewrites the reference to the pyam package and adds it to the docs-pages hosted on RTD (previously, the reference was only included in the Readme).