### PR TITLE
Single constituent region common region bypass

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -416,6 +416,7 @@ class RegionProcessor(BaseModel):
                                     ).rename(region=cr.rename_dict)
                                 )
                                 continue
+                            # if there are multiple constituent regions, aggregate
                             regions = [cr.name, cr.constituent_regions]
                             # First, perform 'simple' aggregation (no arguments)
                             _processed_dfs.append(

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -409,12 +409,7 @@ class RegionProcessor(BaseModel):
                         for cr in self.mappings[model].common_regions:
                             # If the common region is only comprised of a single model
                             # native region, just rename
-                            if (
-                                cr.is_single_constituent_region
-                                and not model_df.filter(
-                                    region=cr.constituent_regions[0]
-                                ).empty
-                            ):
+                            if cr.is_single_constituent_region:
                                 _processed_dfs.append(
                                     model_df.filter(
                                         region=cr.constituent_regions[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ include_package_data = True
 python_requires = >= 3.8
 install_requires =
     click >= 8
-    pyam-iamc >= 0.15  # the pyam package is released on pypi under this name
+    pyam-iamc >= 1.5  # the pyam package is released on pypi under this name
     openpyxl
     setuptools >= 41
     pydantic

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ include_package_data = True
 python_requires = >= 3.8
 install_requires =
     click >= 8
-    pyam-iamc >= 0.12  # the pyam package is released on pypi under this name
+    pyam-iamc >= 0.15  # the pyam package is released on pypi under this name
     openpyxl
     setuptools >= 41
     pydantic

--- a/tests/data/region_processing/rename_only/model_c.yaml
+++ b/tests/data/region_processing/rename_only/model_c.yaml
@@ -1,0 +1,7 @@
+model: model_c
+common_regions:
+  - region_A: [region_a]
+  - region_B:
+    - region_B
+exclude_regions:
+  - region_C

--- a/tests/data/region_processing/skip_aggregation/mappings/model_b.yaml
+++ b/tests/data/region_processing/skip_aggregation/mappings/model_b.yaml
@@ -1,4 +1,4 @@
-model: m_b
+model: model_b
 common_regions:
   - region_A:
     - region_A

--- a/tests/data/region_processing/skip_aggregation/mappings/model_b.yaml
+++ b/tests/data/region_processing/skip_aggregation/mappings/model_b.yaml
@@ -1,0 +1,6 @@
+model: m_b
+common_regions:
+  - region_A:
+    - region_A
+  - region_B:
+    - region_b

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,7 +244,7 @@ def test_region_processing_weighted_aggregation(folder, exp_df, args, caplog):
 
 @pytest.mark.parametrize(
     "model_name, region_names",
-    [("m_a", ("region_A", "region_B")), ("m_b", ("region_A", "region_b"))],
+    [("model_a", ("region_A", "region_B")), ("model_b", ("region_A", "region_b"))],
 )
 def test_region_processing_skip_aggregation(model_name, region_names):
     # Testing two cases:


### PR DESCRIPTION
closes #116.

## Features added

For model mappings that look like this:

```yaml
model: model_a
common_regions:
  - region_A:
    - region_a
```

where a model native region corresponds exactly to a common region we effectively only want to do a renaming.

There was an issue previously where data was still aggregated and in case the aggregation failed data could be lost.
Now there is a check in place to see if a common region only consists of a single constituent region and if so, region processing is bypassed and only a renaming (if necessary) is performed.

I appended two existing unit tests to test or the correct behavior, `test_core.test_region_processing_rename` and `test_core.test_region_processing_skip_aggregation`.

Since this is more of a bugfix than a new feature I did not add anything to the docs but I can of course do that if that's deemed necessary. 