### PR TITLE
Add a docs page for the **testing** module

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -5,28 +5,10 @@
 API documentation
 =================
 
-.. _toplevel_functions:
+.. toctree::
+   :maxdepth: 2
 
-Top-level functions
--------------------
-
-.. autofunction:: process
-
-
-DataStructureDefinition
------------------------
-
-.. autoclass:: DataStructureDefinition
-   :members:
-
-.. autoclass:: nomenclature.codelist.CodeList
-   :members:
-
-Region processing 
------------------
-
-.. autoclass:: RegionProcessor
-   :members:
-
-.. autoclass:: nomenclature.processor.region.RegionAggregationMapping
-   :members:
+   api/nomenclature
+   api/datastructuredefinition
+   api/codelist
+   api/regionprocessor

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -12,3 +12,4 @@ API documentation
    api/datastructuredefinition
    api/codelist
    api/regionprocessor
+   api/testing

--- a/doc/source/api/codelist.rst
+++ b/doc/source/api/codelist.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: nomenclature.codelist
 
-:class:`CodeList`
-=================
+**CodeList**
+============
 
 .. autoclass:: CodeList
    :members:

--- a/doc/source/api/codelist.rst
+++ b/doc/source/api/codelist.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: nomenclature.codelist
+
+:class:`CodeList`
+=================
+
+.. autoclass:: CodeList
+   :members:

--- a/doc/source/api/datastructuredefinition.rst
+++ b/doc/source/api/datastructuredefinition.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: nomenclature
+
+:class:`DataStructureDefinition`
+================================
+
+.. autoclass:: DataStructureDefinition
+   :members:

--- a/doc/source/api/datastructuredefinition.rst
+++ b/doc/source/api/datastructuredefinition.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: nomenclature
 
-:class:`DataStructureDefinition`
-================================
+**DataStructureDefinition**
+===========================
 
 .. autoclass:: DataStructureDefinition
    :members:

--- a/doc/source/api/nomenclature.rst
+++ b/doc/source/api/nomenclature.rst
@@ -1,0 +1,8 @@
+.. _toplevel_functions:
+
+.. currentmodule:: nomenclature
+
+Top-level functions
+===================
+
+.. autofunction:: process

--- a/doc/source/api/regionprocessor.rst
+++ b/doc/source/api/regionprocessor.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: nomenclature
+
+:class:`RegionProcessor`
+=========================
+
+.. autoclass:: RegionProcessor
+   :members:

--- a/doc/source/api/regionprocessor.rst
+++ b/doc/source/api/regionprocessor.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: nomenclature
 
-:class:`RegionProcessor`
-=========================
+**RegionProcessor**
+===================
 
 .. autoclass:: RegionProcessor
    :members:

--- a/doc/source/api/testing.rst
+++ b/doc/source/api/testing.rst
@@ -1,0 +1,8 @@
+.. currentmodule:: nomenclature
+
+The **testing** module
+======================
+
+.. autofunction:: nomenclature.testing.assert_valid_yaml
+
+.. autofunction:: nomenclature.testing.assert_valid_structure

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -28,11 +28,13 @@ def assert_valid_yaml(path: Path):
 
 
 def assert_valid_structure(path: Path):
-    """Assert that `path` is a valid project nomenclature and can be initialized
+    """Assert that `path` can be initialized as a :class:`DataStructureDefinition`
 
-    Valid structure:
-    - A `definitions` folder is required and must be a valid `DataStructureDefinition`
-    - If a `mappings` folder exists, it must be a valid `RegionProcessor`
+    Folder structure of `path`:
+
+      - A `definitions` folder is required and must be a valid
+        :class:`DataStructureDefinition`
+      - If a `mappings` folder exists, it must be a valid :class:`RegionProcessor`
     """
     definition = nomenclature.DataStructureDefinition(path / "definitions")
     if (path / "mappings").is_dir():


### PR DESCRIPTION
This PR adds a page for the testing module to the docs and refactors the API sections into separate pages.

The docs pages are rendered at https://nomenclature-iamc.readthedocs.io/en/docs-testing/