### PR TITLE
Add allowed attributes to variable schema

### DIFF
--- a/nomenclature/validation_schemas/variable_schema.yaml
+++ b/nomenclature/validation_schemas/variable_schema.yaml
@@ -32,6 +32,14 @@ definitions:
                   type: [ string, number, boolean, "null" ]
               minProperties: 1
               maxProperties: 1
+          skip-region-aggregation:
+            type: boolean
+          check-aggregate:
+            type: boolean
+          components:
+            type: array
+            items:
+              type: string
         required:
           - unit
         additionalProperties:


### PR DESCRIPTION
This PR adds the to-be-allowed attributes for the aggregation-check along the variable tree to the variable-code list schema (see #127). This needs to be added before continuing to work on the actual implementation so that PRs on actual projects do not fail the nomenclature-validation.