### PR TITLE
Check that weight variables exist

### DIFF
--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -97,10 +97,9 @@ package. See the section :ref:`model_mapping` for more information.
   :meth:`aggregate_region() <pyam.IamDataFrame.aggregate_region>` will
   be passed to that method. Examples include *method* and *weight*.
 
-* The *weight* attribute specifies a second variable to be used as a weight for
-  computing the aggregation as a weighted average. The variable given in the *weight*
-  attribute **must** have its own entry in the variable list, otherwise an error will be
-  raised.
+* The *weight* attribute is optional. If provided, this variable will be used as a weight for
+  computing the region.aggregation as a weighted average. The variable given in the *weight*
+  attribute **must** be defined in the list of variables.
 
 * It is possible to rename the variable returned by the region processing using
   a *region-aggregation* attribute, which must have a mapping of the target variable to

--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -97,6 +97,11 @@ package. See the section :ref:`model_mapping` for more information.
   :meth:`aggregate_region() <pyam.IamDataFrame.aggregate_region>` will
   be passed to that method. Examples include *method* and *weight*.
 
+* The *weight* attribute specifies a second variable to be used as a weight for
+  computing the aggregation as a weighted average. The variable given in the *weight*
+  attribute **must** have its own entry in the variable list, otherwise an error will be
+  raised.
+
 * It is possible to rename the variable returned by the region processing using
   a *region-aggregation* attribute, which must have a mapping of the target variable to
   arguments of :meth:`aggregate_region() <pyam.IamDataFrame.aggregate_region>`.

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -51,25 +51,27 @@ class CodeList(BaseModel):
 
     name: str
     mapping: Union[
-        List, Dict[str, Dict[str, Union[bool, str, float, int, list, None]]]
+        List,
+        Dict[
+            str,
+            Union[Dict[str, Union[bool, str, float, int, list, dict, None]], List[str]],
+        ],
     ] = {}
 
     @validator("mapping", pre=True)
     def cast_mapping_to_dict(cls, v, values):
         """Cast a mapping provided as list to a dictionary"""
-        if isinstance(v, list):
-            mapping = {}
+        if not isinstance(v, list):
+            return v
 
-            for item in v:
-                if not isinstance(item, Code):
-                    item = Code.from_dict(item)
-                if item.name in mapping:
-                    raise DuplicateCodeError(name=values["name"], code=item.name)
-                mapping[item.name] = item.attributes
-
-            v = mapping
-
-        return v
+        mapping = {}
+        for item in v:
+            if not isinstance(item, Code):
+                item = Code.from_dict(item)
+            if item.name in mapping:
+                raise DuplicateCodeError(name=values["name"], code=item.name)
+            mapping[item.name] = item.attributes
+        return mapping
 
     @validator("mapping")
     def check_variable_region_aggregation_args(cls, v, values):

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -108,12 +108,11 @@ class CodeList(BaseModel):
     def check_weight_in_vars(cls, v, values):
         # Check that all variables specified in 'weight' are present in the codelist
         if values["name"] == "variable":
-            missing_weights = [
+            if missing_weights := [
                 (name, attrs["weight"], attrs["file"])
                 for name, attrs in v.items()
                 if "weight" in attrs and attrs["weight"] not in v
-            ]
-            if missing_weights:
+            ]:
                 raise MissingWeightError(
                     missing_weights="".join(
                         f"'{weight}' used for '{var}' in: {file}\n"

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -121,24 +121,18 @@ class CodeList(BaseModel):
                 )
         return v
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def cast_variable_components_args(cls, values):
+    @validator("mapping")
+    def cast_variable_components_args(cls, v, values):
         """Cast "components" list of dicts to a codelist"""
         if values["name"] == "variable":
-            items = [
-                (name, attrs)
-                for (name, attrs) in values["mapping"].items()
-                if "components" in attrs
-            ]
-
             # translate a list of single-key dictionaries to a simple dictionary
-            for (name, attrs) in items:
-                if not all([isstr(i) for i in attrs["components"]]):
-                    values["mapping"][name]["components"] = CodeList(
+            for name, attrs in v.items():
+                if "components" in attrs and isinstance(attrs["components"][0], dict):
+                    v[name]["components"] = CodeList(
                         name="components", mapping=attrs["components"]
                     ).mapping
 
-        return values
+        return v
 
     def __setitem__(self, key, value):
         if key in self.mapping:

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -1,20 +1,19 @@
 from pathlib import Path
-import yaml
-from typing import Union, Dict, List
-from pydantic import BaseModel, root_validator, validator
-from jsonschema import validate
-import pandas as pd
+from typing import Dict, List, Union
 
+import pandas as pd
+import yaml
+from jsonschema import validate
 from pyam.utils import write_sheet
+from pydantic import BaseModel, validator
 
 from nomenclature.code import Code, Tag, replace_tags
 from nomenclature.error.codelist import DuplicateCodeError
 from nomenclature.error.variable import (
     MissingWeightError,
-    VariableRenameTargetError,
     VariableRenameArgError,
+    VariableRenameTargetError,
 )
-
 
 # arguments of the method `pyam.IamDataFrame.aggregate_region`
 # required for checking validity of variable-CodeList-attributes

--- a/nomenclature/error/variable.py
+++ b/nomenclature/error/variable.py
@@ -20,7 +20,6 @@ class VariableRenameTargetError(PydanticValueError):
 class MissingWeightError(PydanticValueError):
     code = "missing_weight_error"
     msg_template = (
-        "Using 'weight' for aggregation requires the weight variable itself to be "
-        "present in the variable codelist. This is not the case for the following "
-        "variables:\n{missing_weights}"
+        "The following variables are used as 'weight' for aggregation but "
+        "are not defined in the variable codelist:\n{missing_weights}"
     )

--- a/nomenclature/error/variable.py
+++ b/nomenclature/error/variable.py
@@ -15,3 +15,12 @@ class VariableRenameTargetError(PydanticValueError):
         "Region-aggregation-target(s) {target} not defined in the "
         "DataStructureDefinition, occurred in variable '{variable}' (file: {file})"
     )
+
+
+class MissingWeightError(PydanticValueError):
+    code = "missing_weight_error"
+    msg_template = (
+        "Using 'weight' for aggregation requires the weight variable itself to be "
+        "present in the variable codelist. This is not the case for the following "
+        "variables:\n{missing_weights}"
+    )

--- a/tests/data/failing_variable_codelist/unknown_weight/variable/variables.yaml
+++ b/tests/data/failing_variable_codelist/unknown_weight/variable/variables.yaml
@@ -1,0 +1,7 @@
+- Price|Carbon:
+    definition: Price of carbon
+    unit: USD/t CO2
+    weight: Emissions|CO2
+- Capacity Additions|Electricity:
+    unit: EJ
+    weight: Final Energy|Electricity

--- a/tests/test_definition_variable.py
+++ b/tests/test_definition_variable.py
@@ -27,7 +27,7 @@ def test_empty_codelist_raises(dir, error_msg_pattern):
 
 
 def test_unkown_weight_raises():
-    # Check that a weight variable that does not exist on its own raises an error
+    # Check that a weight that is not defined in the variable codelist raises an error
 
     error_pattern = (
         "'weight'.*aggregation.*not the case.*\n"

--- a/tests/test_definition_variable.py
+++ b/tests/test_definition_variable.py
@@ -26,14 +26,15 @@ def test_empty_codelist_raises(dir, error_msg_pattern):
         DataStructureDefinition(TEST_FOLDER_VARIABLE / dir, dimensions=["variable"])
 
 
-def test_unkown_weight_raises():
+def test_unknown_weight_raises():
     # Check that a weight that is not defined in the variable codelist raises an error
+    # Additionally, ensure that all
 
     error_pattern = (
-        "'weight'.*aggregation.*not the case.*\n"
-        "'Emissions|CO2'.*'Price|Carbon'.*variable/variables.yaml\n"
-        "'Final Energy|Electricity'.*'Capacity Additions|Electricity'.*"
-        "variable/variables.yaml"
+        r"'weight'.*aggregation.*not defined.*\n"
+        r"'Emissions\|CO2'.*'Price\|Carbon'.*variable/variables.yaml\n"
+        r"'Final Energy\|Electricity'.*'Capacity Additions\|Electricity'.*"
+        r"variable/variables.yaml"
     )
     with pytest.raises(ValidationError, match=error_pattern):
         DataStructureDefinition(

--- a/tests/test_definition_variable.py
+++ b/tests/test_definition_variable.py
@@ -24,3 +24,18 @@ def test_empty_codelist_raises(dir, error_msg_pattern):
     """Check that initializing a DataStructureDefinition raises expected errors"""
     with pytest.raises(ValidationError, match=error_msg_pattern):
         DataStructureDefinition(TEST_FOLDER_VARIABLE / dir, dimensions=["variable"])
+
+
+def test_unkown_weight_raises():
+    # Check that a weight variable that does not exist on its own raises an error
+
+    error_pattern = (
+        "'weight'.*aggregation.*not the case.*\n"
+        "'Emissions|CO2'.*'Price|Carbon'.*variable/variables.yaml\n"
+        "'Final Energy|Electricity'.*'Capacity Additions|Electricity'.*"
+        "variable/variables.yaml"
+    )
+    with pytest.raises(ValidationError, match=error_pattern):
+        DataStructureDefinition(
+            TEST_FOLDER_VARIABLE / "unknown_weight", dimensions=["variable"]
+        )


### PR DESCRIPTION
Closes #132.

## Features added

The validation of the variable code list now includes a check that all variables mentioned as a `weight` also have their own entry in the list. I've written the validator so that it collects **all** missing weight variables and does not throw an error for the first one. This way multiple errors can be fixed in one go.
I added a point in the documentation to highlight that the weight is required. 
I also took the liberty to slightly refactor the codelist validators. The main change there is the switch from using `root_validator()` to `validator("mapping")`.
The reason for this change is that in the validators only modify and validate the `mapping` attribute. The `name` attribute is mainly used for better error reporting in this case. The way how to access multiple attributes in a non-root validator is adding `v` and `values` to the list of input variables (details can be found under the code example of "Validators" https://pydantic-docs.helpmanual.io/usage/validators/). As an example:

```
@validator("mapping")
def some_validator(cls, v, values):
    # v is the field to be validated "mapping" in our case
    # values is a dict, that contains all other previously validated fields
```

If you don't like the switch from the `root_validator` though I can also revert it.
Looking forward to your comments.