### PR TITLE
Cast `components`-attribute to dict instead of CodeList

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -115,7 +115,7 @@ class CodeList(BaseModel):
                 if not all([isstr(i) for i in attrs["components"]]):
                     values["mapping"][name]["components"] = CodeList(
                         name="components", mapping=attrs["components"]
-                    )
+                    ).mapping
 
         return values
 

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -94,7 +94,7 @@ class DataStructureDefinition:
                     components = attr.get("components", None)
 
                     # check if multiple lists of components are given for a code
-                    if isinstance(components, CodeList):
+                    if isinstance(components, dict):
                         for name, _components in components.items():
                             error = df.check_aggregate(code, _components, **kwargs)
                             if error is not None:

--- a/tests/test_check_aggregate.py
+++ b/tests/test_check_aggregate.py
@@ -37,11 +37,20 @@ def expected_fail_return(name):
     return pd.DataFrame([[9.0, 10.0], [8.0, 7.0]], columns=columns, index=index)
 
 
-@pytest.mark.parametrize("components", ["components", "components_dict"])
-def test_check_aggregate_passing(components):
+@pytest.mark.parametrize(
+    "components, components_type",
+    [
+        ("components", list),
+        ("components_dict", dict),
+    ],
+)
+def test_check_aggregate_passing(components, components_type):
     """Assert that the aggregate-check passes with different types of components"""
 
     dsd = DataStructureDefinition(TEST_DATA_DIR / "check_aggregate" / components)
+
+    # check that components is returned as a basic type (not a codelist)
+    assert isinstance(dsd.variable["Final Energy"]["components"], components_type)
 
     # aggregation check returns None if no inconsistencies are found
     assert dsd.check_aggregate(TEST_DF) is None


### PR DESCRIPTION
Closes #135.

This PR (still) uses the CodeList-casting to parse the structure of the **components** attribute as a list of single-key-dicts to a dictionary, but then extracts the dictionary so that the actual **components** attribute is really just a simple dictionary. I think that this is an elegant solution to avoid nested CodeList structure while still re-using the parsing and validation of the CodeList-initialization. And I added a test...