### PR TITLE
Docs/add howto

### DIFF
--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -47,4 +47,5 @@ the RegionProcessor and validated using DataStructureDefinition.
   user_guide/variable
   user_guide/region
   user_guide/model-mapping
+  user_guide/howto
   user_guide/local-usage

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -52,10 +52,10 @@ many projects. For the ``common_regions``, there are ``World`` and ``Common regi
 Region definitions
 ^^^^^^^^^^^^^^^^^^
 
-Regions ``model_a|Region 1, model_a|Region 2, model_a|Region 3, World`` and ``Common
-region 1`` **must** be **part** of the region definitions. 
+Regions ``model_a|Region 1``, ``model_a|Region 2``, ``model_a|Region 3``, ``World`` and
+``Common region 1`` **must** be **part** of the region definitions. 
 
-``region_1, region_2`` and ``region_3`` are **not required** since they refer to the
+``region_1``, ``region_2`` and ``region_3`` are **not required** since they refer to the
 input names of ``model_a``'s regions and will be renamed in the processing.
 
 In most cases, the common regions (in the above example ``World`` and ``Common region

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -17,7 +17,7 @@ Using the region-processing of a **nomenclature**-based project workflow require
 specifications: 
 
 * a model mapping to perform region aggregation from *native_regions* to
-*common_regions* and renaming of model native regions
+  *common_regions* and renaming of model native regions
 * a list of region names as they should appear in the processed scenario data
 
 Region aggregation mapping

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -7,7 +7,6 @@ Model registration
 
 This guide presents a quick instruction for "registering a model" in a project workflow.
 
-is intended as a quick instruction for adding a model to comparison project.
 It is still recommended to read the detailed instructions under :ref:`model_mapping` and
 :ref:`region` in particular.
 
@@ -15,11 +14,18 @@ Region processing
 -----------------
 
 Using the region-processing of a **nomenclature**-based project workflow requires two specifications:
+- a model mapping to perform region aggregation from *native_regions* to
+*common_regions* and renaming of model native regions
 - a list of region names as they should appear in the processed scenario data
-- a mapping to perform region aggregation from *native_regions* to *common_regions*
 
-As outlined in :ref:`model_mapping` a model mapping holds the information about model
-native an aggregation regions, for example:
+Region aggregation mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As described in :ref:`model_mapping`, the model mapping holds the information about
+aggregating from native regions to common regions. It also allows renaming of native
+regions for disambiguation in a scenario ensemble.
+
+Example:
 
 .. code-block:: yaml
 
@@ -41,32 +47,26 @@ native an aggregation regions, for example:
 These three are to be renamed to the ``{model}|{region}`` pattern as is common place in
 many projects. For the ``common_regions``, there are ``World`` and ``Common region 1``.
 
-If this model mapping would be submitted as a pull request to a project repository, the
-:func:`assert_valid_structure` (details can be found here: :ref:`cli`) test that is run
-automatically would most likely fail.
+Region definitions
+^^^^^^^^^^^^^^^^^^
 
-The reason for this is that it is required for all regions that will be part of the
-processing output according to a model mapping to be defined in the list of regions in
-the ``definitions/region/`` folder. 
+Regions ``model_a|Region 1, model_a|Region 2, model_a|Region 3, World`` and ``Common
+region 1`` **must** be **part** of the region definitions. 
 
-In case of the example mapping above, regions ``model_a|Region 1, model_a|Region 2,
-model_a|Region 3, World`` and ``Common region 1`` must be part of the region
-definitions. ``region_1, region_2`` and ``region_3`` are not required since they will
-not be part of the processing output as they will be renamed.
+``region_1, region_2`` and ``region_3`` are **not required** since they refer to the
+input names of ``model_a``'s regions and will be renamed in the processing.
 
-In most cases the common regions will already be fined. There will, most likely exist a
-file ``defintions/region/regions.yaml`` which contains the project's common regions.
+In most cases, the common regions (in the above example ``World`` and ``Common region
+1``) will already be defined in a file called ``definitions/region/regions.yaml``.
 
-For the model native regions, however, the regions will most likely not exist. Therefore
-a new yaml file needs to be added to the same pull request that contains the model
-mapping. Per convention the ``definitions/region`` folder usually contains a subfolder
-called ``model_native_regions`` which is where all files containing model native region
-definitions should be put. The name of the file is not functionally relevant but it is
-recommended to use the model name.
+The model native regions, however, will most likely need to be added. For this, a new
+yaml file should be created, usually in ``definitions/region/model_native_regions``. The
+name of the file is not functionally relevant but it is recommended to use the model
+name.
 
-In order to make to above example model mapping work and the test run, we would
-therefore add a file called ``model_a.yaml`` to
-``definitions/region/model_native_regions`` with the following content:
+In order to complete the model registration for the example above, we would therefore
+add a file called ``model_a.yaml`` to ``definitions/region/model_native_regions/`` with
+the following content:
 
 .. code-block:: yaml
 
@@ -75,5 +75,13 @@ therefore add a file called ``model_a.yaml`` to
       - model_a|Region 2
       - model_a|Region 3
 
-assuming ``World`` and ``Common region 1`` are already defined, this should make the
-tests pass.
+The combination of a model mapping and the definition of all regions that are part of
+the processing output constitutes a complete model registration.
+
+Continuous Integration
+----------------------
+
+In most cases, a model registration is submitted as a pull request to a project. As part
+of this, :func:`assert_valid_structure` (details can be found here: :ref:`cli`) is run
+automatically to assure that the model registration is valid. Any regions that are, for
+example mentioned in a mapping but not defined will raise an error.

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -17,7 +17,7 @@ Region processing
 specifications: 
 
 * a model mapping to perform region aggregation from *native_regions* to
-  *common_regions* and renaming of model native regions
+  *common_regions* and renaming of model native regions (optional)
 * a list of region names as they should appear in the processed scenario data
 
 Model mapping
@@ -50,7 +50,7 @@ Region definitions
 
 In order to constitute a valid "model registration", regions ``model_a|Region 1``,
 ``model_a|Region 2``, ``model_a|Region 3``, ``World`` and ``Common region 1`` **must**
-be **part** of the region definitions. 
+be part of the region definitions. 
 
 ``region_1``, ``region_2`` and ``region_3`` are **not required** since they refer to the
 input names of ``model_a``'s regions and will be renamed in the processing.
@@ -80,7 +80,7 @@ the processing output constitutes a complete model registration.
 Continuous Integration
 ----------------------
 
-In most cases, a model registration is submitted as a pull request to a project. As part
+In most cases, a model registration is submitted as a pull request to a project repository hosted on GitHub. As part
 of this, :func:`assert_valid_structure` (details can be found here: :ref:`cli`) is run
-automatically to assure that the model registration is valid. Any regions that are, for
+automatically to ensure that the model registration is valid. Any regions that are, for
 example mentioned in a mapping but not defined will raise an error.

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -1,0 +1,73 @@
+.. _how-to:
+
+.. currentmodule:: nomenclature
+
+This guide is intended as a quick instruction for adding a model to comparison project.
+It is still recommended to read the detailed instructions under :ref:`model_mapping` and
+:ref:`region` in particular.
+
+How to add your model mapping to a project repository
+=====================================================
+
+There are two parts to adding a new model mapping. The mapping itself and the easily
+forgotten additionally required region definitions. 
+
+As outlined in :ref:`model_mapping` a model mapping holds the information about model
+native an aggregation regions, for example:
+
+.. code-block:: yaml
+
+    model: model_a
+    native_regions:
+      - region_1: model_a|Region 1
+      - region_2: model_a|Region 2
+      - region_3: model_a|Region 3
+    common_regions:
+      - World:
+        - region_1
+        - region_2
+        - region_3
+      - Common region 1:
+        - region_1
+        - region_2
+
+``model_a`` reports three regions natively, ``region_1``, ``region_2`` and ``region_3``.
+These three are to be renamed to the ``{model}|{region}`` pattern as is common place in
+many projects. For the ``common_regions``, there are ``World`` and ``Common region 1``.
+
+If this model mapping would be submitted as a pull request to a project repository, the
+:func:`assert_valid_structure` (details can be found here: :ref:`cli`) test that is run
+automatically would most likely fail.
+
+The reason for this is that it is required for all regions that will be part of the
+processing output according to a model mapping to be defined in the list of regions in
+the ``definitions/region/`` folder. 
+
+In case of the example mapping above, regions ``model_a|Region 1, model_a|Region 2,
+model_a|Region 3, World`` and ``Common region 1`` must be part of the region
+definitions. ``region_1, region_2`` and ``region_3`` are not required since they will
+not be part of the processing output as they will be renamed.
+
+In most cases the common regions will already be fined. There will, most likely exist a
+file ``defintions/region/regions.yaml`` which contains the project's common regions.
+
+For the model native regions, however, the regions will most likely not exist. Therefore
+a new yaml file needs to be added to the same pull request that contains the model
+mapping. Per convention the ``definitions/region`` folder usually contains a subfolder
+called ``model_native_regions`` which is where all files containing model native region
+definitions should be put. The name of the file is not functionally relevant but it is
+recommended to use the model name.
+
+In order to make to above example model mapping work and the test run, we would
+therefore add a file called ``model_a.yaml`` to
+``definitions/region/model_native_regions`` with the following content:
+
+.. code-block:: yaml
+
+    model_a:
+      - model_a|Region 1
+      - model_a|Region 2
+      - model_a|Region 3
+
+assuming ``World`` and ``Common region 1`` are already defined, this should make the
+tests pass.

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -13,21 +13,17 @@ It is still recommended to read the detailed instructions under :ref:`model_mapp
 Region processing
 -----------------
 
-Using the region-processing of a **nomenclature**-based project workflow requires two
+"Registering a model" for a **nomenclature**-based project workflow requires two
 specifications: 
 
 * a model mapping to perform region aggregation from *native_regions* to
   *common_regions* and renaming of model native regions
 * a list of region names as they should appear in the processed scenario data
 
-Region aggregation mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Model mapping
+^^^^^^^^^^^^^
 
-As described in :ref:`model_mapping`, the model mapping holds the information about
-aggregating from native regions to common regions. It also allows renaming of native
-regions for disambiguation in a scenario ensemble.
-
-Example:
+For this guide we will consider a model mapping as an example:
 
 .. code-block:: yaml
 
@@ -52,8 +48,9 @@ many projects. For the ``common_regions``, there are ``World`` and ``Common regi
 Region definitions
 ^^^^^^^^^^^^^^^^^^
 
-Regions ``model_a|Region 1``, ``model_a|Region 2``, ``model_a|Region 3``, ``World`` and
-``Common region 1`` **must** be **part** of the region definitions. 
+In order to constitute a valid "model registration", regions ``model_a|Region 1``,
+``model_a|Region 2``, ``model_a|Region 3``, ``World`` and ``Common region 1`` **must**
+be **part** of the region definitions. 
 
 ``region_1``, ``region_2`` and ``region_3`` are **not required** since they refer to the
 input names of ``model_a``'s regions and will be renamed in the processing.
@@ -61,8 +58,8 @@ input names of ``model_a``'s regions and will be renamed in the processing.
 In most cases, the common regions (in the above example ``World`` and ``Common region
 1``) will already be defined in a file called ``definitions/region/regions.yaml``.
 
-The model native regions, however, will most likely need to be added. For this, a new
-yaml file should be created, usually in ``definitions/region/model_native_regions``. The
+The model native regions, however, most likely need to be added. For this, a new yaml
+file should be created, usually in ``definitions/region/model_native_regions/``. The
 name of the file is not functionally relevant but it is recommended to use the model
 name.
 
@@ -77,7 +74,7 @@ the following content:
       - model_a|Region 2
       - model_a|Region 3
 
-The combination of a model mapping and the definition of all regions that are part of
+This combination of a model mapping and the definition of all regions that are part of
 the processing output constitutes a complete model registration.
 
 Continuous Integration

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -2,15 +2,21 @@
 
 .. currentmodule:: nomenclature
 
-This guide is intended as a quick instruction for adding a model to comparison project.
+Model registration
+==================
+
+This guide presents a quick instruction for "registering a model" in a project workflow.
+
+is intended as a quick instruction for adding a model to comparison project.
 It is still recommended to read the detailed instructions under :ref:`model_mapping` and
 :ref:`region` in particular.
 
-How to add your model mapping to a project repository
-=====================================================
+Region processing
+-----------------
 
-There are two parts to adding a new model mapping. The mapping itself and the easily
-forgotten additionally required region definitions. 
+Using the region-processing of a **nomenclature**-based project workflow requires two specifications:
+- a list of region names as they should appear in the processed scenario data
+- a mapping to perform region aggregation from *native_regions* to *common_regions*
 
 As outlined in :ref:`model_mapping` a model mapping holds the information about model
 native an aggregation regions, for example:

--- a/doc/source/user_guide/howto.rst
+++ b/doc/source/user_guide/howto.rst
@@ -13,10 +13,12 @@ It is still recommended to read the detailed instructions under :ref:`model_mapp
 Region processing
 -----------------
 
-Using the region-processing of a **nomenclature**-based project workflow requires two specifications:
-- a model mapping to perform region aggregation from *native_regions* to
+Using the region-processing of a **nomenclature**-based project workflow requires two
+specifications: 
+
+* a model mapping to perform region aggregation from *native_regions* to
 *common_regions* and renaming of model native regions
-- a list of region names as they should appear in the processed scenario data
+* a list of region names as they should appear in the processed scenario data
 
 Region aggregation mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/user_guide/local-usage.rst
+++ b/doc/source/user_guide/local-usage.rst
@@ -8,11 +8,11 @@ Local usage of a project
 .. attention:: This page is intended for users who are familiar with Python,
     `git <https://git-scm.com>`_  and a service like `GitHub <https://github.com>`_.
 
-You can use the **nomenclature** package locally (on your machine) for validation
-and region-aggregration. This can be helpful as part of processing your model results,
-or to ensure that a submission to an IIASA Scenario Explorer instance will succeed.
+You can use the **nomenclature** package locally (on your machine) for validation and
+region-aggregration. This can be helpful as part of processing your model results, or to
+ensure that a submission to an IIASA Scenario Explorer instance will succeed.
 
-The following **requirements** must be satisfied to use a :class:´nomenclature`-based
+The following **requirements** must be satisfied to use a :class:`nomenclature`-based
 project locally:
 
 1. Install the **nomenclature** package (see the :ref:`installation` instructions)
@@ -28,13 +28,13 @@ project locally:
 Validation against codelists
 ----------------------------
 
-The easiest use case is to validate that a data file or an
-:class:`IamDataFrame <pyam.IamDataFrame>` is compatible with the codelists
-(lists of variables and regions) of a project's :class:`DataStructureDefinition`.
+The easiest use case is to validate that a data file or an :class:`IamDataFrame
+<pyam.IamDataFrame>` is compatible with the codelists (lists of variables and regions)
+of a project's :class:`DataStructureDefinition`.
 
-If there are inconsistencies with the codelists, the method
-:meth:`validate <DataStructureDefinition.validate>` will raise an error.
-If the scenario data is consistent, the method returns *True*.
+If there are inconsistencies with the codelists, the method :meth:`validate
+<DataStructureDefinition.validate>` will raise an error. If the scenario data is
+consistent, the method returns *True*.
 
 .. code-block:: python
 

--- a/doc/source/user_guide/model-registration.rst
+++ b/doc/source/user_guide/model-registration.rst
@@ -1,4 +1,4 @@
-.. _how-to:
+.. _model-registration:
 
 .. currentmodule:: nomenclature
 
@@ -60,8 +60,7 @@ In most cases, the common regions (in the above example ``World`` and ``Common r
 
 The model native regions, however, most likely need to be added. For this, a new yaml
 file should be created, usually in ``definitions/region/model_native_regions/``. The
-name of the file is not functionally relevant but it is recommended to use the model
-name.
+file does not need to have any special name but it is recommended to use the model name.
 
 In order to complete the model registration for the example above, we would therefore
 add a file called ``model_a.yaml`` to ``definitions/region/model_native_regions/`` with

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -9,13 +9,24 @@ cli = click.Group()
 @cli.command("validate-yaml")
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 def cli_valid_yaml(path: Path):
-    """Assert that all yaml files in `path` can be parsed without errors"""
+    """Assert that all yaml files in `path` are syntactically valid."""
     assert_valid_yaml(path)
 
 
 @cli.command("validate-project")
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 def cli_valid_project(path: Path):
-    """Assert that `path` is a valid project nomenclature"""
+    """Assert that `path` is a valid project nomenclature
+
+    This test includes three steps:
+
+    1. Test that all yaml files in `definitions/` and `mappings/` can be correctly read
+       as yaml files. This is a formal check for yaml syntax only.
+    2. Test that all files in `definitions/` can be correctly parsed as a
+       :class:`DataStructureDefinition` object comprised of individual codelists.
+    3. Test that all model mappings in `mappings/` can be correctly parsed as a
+       :class:`RegionProcessor` object. This includes a check that all regions mentioned
+       in a model mapping are defined in the region codelist.
+    """
     assert_valid_yaml(path)
     assert_valid_structure(path)


### PR DESCRIPTION
Closes #142. 
Opened in favor of #143.

This is my first attempt at a "how to" detailing the common pitfall of adding a model mapping without the corresponding region definition files.
As the "how to" referenced the nomenclature validate-project cli command, I added some additional docstring explanation that does not seem to be rendered currently by sphinx-click. Additionally, the direct referencing of a cli command seems to not be possible at the moment (https://sphinx-click.readthedocs.io/en/latest/usage/#cross-referencing) so I liked the CLI page.

A preview of the updated docs is rendered here: https://nomenclature-iamc.readthedocs.io/en/docs-add-howto/