### PR TITLE
Change path representation to posix style

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     name: py${{ matrix.python-version }}
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     name: py${{ matrix.python-version }}
 
     steps:

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -228,7 +228,9 @@ class CodeList(BaseModel):
 
                 # add `file` attribute to each element and add to main list
                 for item in _code_list:
-                    item.set_attribute("file", str(yaml_file.relative_to(path.parent)))
+                    item.set_attribute(
+                        "file", yaml_file.relative_to(path.parent).as_posix()
+                    )
                 code_list.extend(_code_list)
 
         # replace tags by the items of the tag-dictionary


### PR DESCRIPTION
closes #148.

As per discussion in #148 changing the file path in `CodeList` entries to be represented as a posix style path.
For the first CI run I changed nothing and only set the OS to `windows-latest` to reproduce the error.