### PR TITLE
Add nightly run with multiple OS

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,7 @@ name: nightly
 on:
   schedule:
     # runs once per week on Sunday at 3am UCT
-    - cron: '0 3 * * 7'
+    - cron: '0 3 * * 0'
 jobs:
   pytest:
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,37 @@
+
+# This workflow installs the package and runs the tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: nightly
+
+on:
+  schedule:
+    # runs once per week on Sunday at 3am UCT
+    - cron: '0 3 * * 7'
+jobs:
+  pytest:
+
+    strategy:
+      matrix:
+        # keep consistent with py-version badge in README.md and doc/source/index.rst
+        # update setup.cfg and doc/source/installation.rst when deprecating python 3.8
+        python-version: ['3.8', '3.9', '3.10']        
+      fail-fast: false
+    runs-on: ubuntu-latest
+    name: py${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install the latest pyam version from source
+      run: pip install git+https://github.com/IAMconsortium/pyam.git
+
+    - name: Install (other) dependencies and package
+      run: pip install --editable .[tests]
+
+    - name: Test with pytest
+      run: pytest tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [ '**' ]
   schedule:
-    cron: '0 3 * * *'
+    - cron: '0 3 * * *'
 jobs:
   pytest:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,8 +9,6 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ '**' ]
-  schedule:
-    - cron: '0 3 * * 7'
 jobs:
   pytest:
 
@@ -22,7 +20,6 @@ jobs:
         os: [ubuntu, macos, windows]
       fail-fast: false
     # for non-nightly run only ubuntu, for nightly run all three OS
-    if: ${{ (matrix.os == 'ubuntu') || (github.event_name == 'schedule') }}
     runs-on: ${{ matrix.os }}-latest
     name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}'
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu, macos, windows]
       fail-fast: false
     # for non-nightly run only ubuntu, for nightly run all three OS
-    if: ${{ matrix.os == 'ubuntu'}} || ${{ github.event_name == 'schedule' }}
+    if: ${{ (matrix.os == 'ubuntu') || (github.event_name == 'schedule') }}
     runs-on: ${{ matrix.os }}-latest
     name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}'
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     # for non-nightly run only ubuntu, for nightly run all three OS
     if: ${{ matrix.os == 'ubuntu'}} || ${{ github.event_name == 'schedule' }}
     runs-on: ${{ matrix.os }}-latest
-    name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}''
+    name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}'
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']        
         os: [ubuntu, macos, windows]
       fail-fast: false
-    # for non-nightly run only ubuntu, for nightly run all three OS
+    
     runs-on: ${{ matrix.os }}-latest
     name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}'
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [ '**' ]
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 * * 7'
 jobs:
   pytest:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,24 +9,22 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ '**' ]
-
+  schedule:
+    cron: '0 3 * * *'
 jobs:
   pytest:
 
     strategy:
       matrix:
-        python-version:
         # keep consistent with py-version badge in README.md and doc/source/index.rst
         # update setup.cfg and doc/source/installation.rst when deprecating python 3.8
-        - '3.10'
-        - '3.9'
-        - '3.8'
-
+        python-version: ['3.8', '3.9', '3.10']        
+        os: [ubuntu, macos, windows]
       fail-fast: false
-
-    runs-on: ubuntu-latest
-    name: py${{ matrix.python-version }}
-
+    # for non-nightly run only ubuntu, for nightly run all three OS
+    if: ${{ matrix.os == 'ubuntu'}} || ${{ github.event_name == 'schedule' }}
+    runs-on: ${{ matrix.os }}-latest
+    name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}''
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
As discussed yesterday in #148 running integration tests for multiple operating systems for every PR is overkill.

I still think that running them once per day as a nightly run on the main branch can be useful to catch operating system dependent bugs early. I slightly modified `pytest.yaml` so that it now also runs every day at 3am UTC. In addition, only for these scheduled nightly runs, we also run them on `macos-latest` and `windows-latest`.

@danielhuppmann if you think it's not a good idea, I can also close the PR.