### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,23 +11,19 @@ authors:
   - given-names: Daniel
     family-names: Huppmann
     affiliation: >-
-      International Institute for Applied Systems
-      Analysis (IIASA)
+      International Institute for Applied Systems Analysis (IIASA)
     orcid: 'https://orcid.org/0000-0002-7729-7389'
   - given-names: Laura
     family-names: Wienpahl
     affiliation: >-
-      International Institute for Applied Systems
-      Analysis (IIASA)
+      International Institute for Applied Systems Analysis (IIASA)
     orcid: 'https://orcid.org/0000-0003-2049-8531'
   - given-names: Philip
     family-names: Hackstock
     affiliation: >-
-      International Institute for Applied Systems
-      Analysis (IIASA)
+      International Institute for Applied Systems Analysis (IIASA)
     orcid: 'https://orcid.org/0000-0002-1482-1366'
   - given-names: Lucie
     family-names: Castella
     affiliation: >-
-      International Institute for Applied Systems
-      Analysis (IIASA)
+      International Institute for Applied Systems Analysis (IIASA)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,11 +23,11 @@ authors:
   - given-names: Philip
     family-names: Hackstock
     affiliation: >-
-      International Institue for Applied Systems
+      International Institute for Applied Systems
       Analysis (IIASA)
     orcid: 'https://orcid.org/0000-0002-1482-1366'
   - given-names: Lucie
     family-names: Castella
     affiliation: >-
-      International Institue for Applied Systems
+      International Institute for Applied Systems
       Analysis (IIASA)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,3 +27,4 @@ authors:
     family-names: Castella
     affiliation: >-
       International Institute for Applied Systems Analysis (IIASA)
+    orcid: 'https://orcid.org/0000-0002-6049-0406'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: nomenclature
+message: >-
+  If you use this package please cite the doi
+  corresponding to the release used
+type: software
+authors:
+  - given-names: Daniel
+    family-names: Huppmann
+    affiliation: >-
+      International Institute for Applied Systems
+      Analysis (IIASA)
+    orcid: 'https://orcid.org/0000-0002-7729-7389'
+  - given-names: Laura
+    family-names: Wienpahl
+    affiliation: >-
+      International Institute for Applied Systems
+      Analysis (IIASA)
+    orcid: 'https://orcid.org/0000-0003-2049-8531'
+  - given-names: Philip
+    family-names: Hackstock
+    affiliation: >-
+      International Institue for Applied Systems
+      Analysis (IIASA)
+    orcid: 'https://orcid.org/0000-0002-1482-1366'
+  - given-names: Lucie
+    family-names: Castella
+    affiliation: >-
+      International Institue for Applied Systems
+      Analysis (IIASA)


### PR DESCRIPTION
As we're nearing a new release and we have our first contribution from @luciecastella :tada: I thought it would be a good idea to add a `CITATION.cff` so that for future releases we have all authors documented on Zenodo as well.