### PR TITLE
Check if user provided "mapping" attribute in assert_valid_structure

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,8 +3,6 @@ linters:
     black:
     flake8:
         python: 3
-        ignore: 
-            - W605
-            - W503
+        ignore: W605, W503
         max-line-length: 88
         max-complexity: 20

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -32,13 +32,13 @@ def cli_valid_yaml(path: Path):
     default="['region', 'variable']",
 )
 @click.option(
-    "--mappings", help="Optional name for mappings folder", type=str, default="mappings"
+    "--mappings", help="Optional name for mappings folder", type=str, default=None
 )
 @click.option(
     "--definitions",
     help="Optional name for definitions folder",
     type=str,
-    default=None,
+    default="definitions",
 )
 def cli_valid_project(
     path: Path, dimensions: List[str], mappings: str, definitions: str

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -38,7 +38,7 @@ def cli_valid_yaml(path: Path):
     "--definitions",
     help="Optional name for definitions folder",
     type=str,
-    default="definitions",
+    default=None,
 )
 def cli_valid_project(
     path: Path, dimensions: List[str], mappings: str, definitions: str

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -31,7 +31,7 @@ def assert_valid_yaml(path: Path):
 def assert_valid_structure(
     path: Path,
     dimensions: List[str] = ["region", "variable"],
-    mappings: str = "mappings",
+    mappings: str = None,
     definitions: str = "definitions",
 ) -> None:
     """Assert that `path` can be initialized as a :class:`DataStructureDefinition`
@@ -41,11 +41,11 @@ def assert_valid_structure(
     path : Path
         directory path to the file of interest
     dimensions : List[str]
-        Optionnal list of dimensions to be checked
+        Optional list of dimensions to be checked
     mappings : str
-        Optionnal non-default name for the mappings folder
+        Optional non-default name for the mappings folder, default "mappings"
     definitions : str
-        Optionnal non-default name for the definitions folder
+        Optional non-default name for the definitions folder
 
     Notes
     -----
@@ -57,15 +57,17 @@ def assert_valid_structure(
     """
 
     definition = nomenclature.DataStructureDefinition(path / definitions, dimensions)
-    if (path / mappings).is_dir():
+    if mappings is None:
+        if (path / "mappings").is_dir():
+            nomenclature.RegionProcessor.from_directory(
+                path / "mappings"
+            ).validate_mappings(definition)
+    elif (path / mappings).is_dir():
         nomenclature.RegionProcessor.from_directory(path / mappings).validate_mappings(
             definition
         )
     else:
-        if mappings != "mappings":
-            raise FileNotFoundError(
-                f"Mappings directory not found: {path/ str(mappings)}"
-            )
+        raise FileNotFoundError(f"Mappings directory not found: {path / mappings}")
 
 
-# Todo: add function which runs `DataStrutureDefinition(path).validate(scenario)`
+# Todo: add function which runs `DataStructureDefinition(path).validate(scenario)`

--- a/tests/data/structure_validation_no_mappings/definitions/region/regions.yaml
+++ b/tests/data/structure_validation_no_mappings/definitions/region/regions.yaml
@@ -1,0 +1,4 @@
+- common:
+    - World
+- country:
+    - Austria

--- a/tests/data/structure_validation_no_mappings/definitions/variable/variables.yaml
+++ b/tests/data/structure_validation_no_mappings/definitions/variable/variables.yaml
@@ -1,0 +1,3 @@
+- Primary Energy:
+    definition: Total primary energy consumption
+    unit: EJ/yr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,3 +165,37 @@ def test_cli_custom_dimensions_fails():
         ],
     )
     assert result_valid.exit_code == 1
+
+
+def test_cli_missing_mappings_runs():
+    """Assert that when **no** mappings folder is given by the user it's allowed
+    to not exist"""
+
+    assert (
+        runner.invoke(
+            cli,
+            [
+                "validate-project",
+                str(TEST_DATA_DIR / "structure_validation_no_mappings"),
+            ],
+        ).exit_code
+        == 0
+    )
+
+
+def test_cli_missing_mappings_fails():
+    """Assert that when a mappings folder is specified it needs to exist"""
+
+    cli_result = runner.invoke(
+        cli,
+        [
+            "validate-project",
+            str(TEST_DATA_DIR / "structure_validation_no_mappings"),
+            "--mappings",
+            "mappings",
+        ],
+    )
+
+    assert cli_result.exit_code == 1
+    assert isinstance(cli_result.exception, FileNotFoundError)
+    assert "Mappings directory not found" in str(cli_result.exception)


### PR DESCRIPTION
closes #155.

Quick little PR to address the logic improvements discussed in #153.

## Features implemented

`testing.assert_valid_structure` now has the following default `mapping: str = None`. This means that we can now distinguish if the user provided input or we are using our default. This allows for the following logic:
* If `mapping is None`, check if a folder called `"mappings/"` (the previous default value) exists. If so check the mappings, if not exit **without** an error. This is the desired behavior since mappings are not strictly required. 
* If the user provided a value for `mapping`. Check if a folder of that name exists. If so check the mappings, if not, raise a `FileNotFound` error. The logic here being that if the user provided a value for `mappings` it needs to exist.