### PR TITLE
Add common vs native region explanation

### DIFF
--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -21,9 +21,14 @@ Difference between model-native and common regions
 Model native regions are regions that are reported *directly* from an integrated
 assessment model. 
 
-Common regions, on the other hand, are calculated by *aggregating model native*
-regions. Common regions are used to compare results from models with different
-native regional resolution. 
+Common regions, on the other hand, are calculated by *aggregating* a model's *native*
+regions. Common regions are used to compare results from models with different native
+regional resolution. 
+
+As an example, let's say we have two models *model_a* and *model_b*. model_a reports
+native regions *Western* and *Eastern Europe* while *model_b* reports *Northern* and
+*Southern Europe*. In order to compare the results of the two models we might introduce
+a common region called *Europe*. 
 
 
 Model mapping format specification

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -13,6 +13,18 @@ purposes:
 2. Allowing for renaming of model native regions.
 3. Defining how model native regions should be aggregated to common regions.
 
+.. _native-vs-common-region:
+
+Difference between model-native and common regions
+---------------------------------------------------
+
+Model native regions are regions that are reported *directly* from an integrated
+assessment model. 
+
+Common regions, on the other hand, are calculated by *aggregating model native*
+regions. Common regions are used to compare results from models with different
+native regional resolution. 
+
 
 Model mapping format specification
 ----------------------------------

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -3,15 +3,13 @@
 Region processing using model mappings
 ======================================
 
-Model mappings, defined on a per-model basis for region processing serve three
-different purposes:
+Model mappings, defined on a per-model basis for region processing serve three different
+purposes:
 
-1. Defining a list of model native regions under the key *native_regions* that
-   are to be selected (and usually uploaded) from an IAM result. This also
-   serves as an implicit exclusion list for model native regions, since only
-   explicitly mentioned regions are selected. Any region not mentioned in
-   *native_regions* will cause an error unless explicitly named in the
-   *exclude_regions* section. This to avoid accidentally forgetting a region.
+1. Defining a list of model native regions under the key *native_regions* that are to be
+   selected (and usually uploaded) from an IAM result. This also serves as an implicit
+   exclusion list for model native regions, since only explicitly mentioned regions are
+   selected. Any region not mentioned in *native_regions* will cause an error unless explicitly named in the *exclude_regions* section. This to avoid accidentally forgetting a region.
 2. Allowing for renaming of model native regions.
 3. Defining how model native regions should be aggregated to common regions.
 
@@ -53,40 +51,39 @@ This example illustrates how such a model mapping looks like:
   * *exclude_regions*
 
 *  *model* (str or list of str): the model name(s) for which the mapping applies.
-*  *native_regions* (list): a list of model native regions serves as a selection
-   as to which regions to keep.
+*  *native_regions* (list): a list of model native regions serves as
+   a selection as to which regions to keep.
 
-   *  In the above example *region_a* is to be renamed to *alternative_name_a*.
-      This is done by defining a key-value pair of *model_native_name:
-      new_name*.
+   *  In the above example *region_a* is to be renamed to
+      *alternative_name_a*. This is done by defining a key-value pair
+      of *model_native_name: new_name*.
    *  *region_b* is selected but the name is not changed.
-   *  Assuming *model_a* also defines a third region *region_c*, since it is not
-      mentioned it will be **dropped** from the data.
+   *  Assuming *model_a* also defines a third region *region_c*,
+      since it is not mentioned it will be **dropped** from the data.
 
-*  *common_regions* (list): list of common regions which will be computed as
-   aggregates. They are defined as list entries which themselves have a list of
-   constituent regions. These constituent regions must be model native regions.
+*  *common_regions* (list): list of common regions which will be computed as aggregates.
+   They are defined as list entries which themselves have a list of constituent regions.
+   These constituent regions must be model native regions.
 
-   The names of the constituent regions **must** refer to the **original** model
-   native region names. In the above example *region_a* and *region_b* and
-   **not** *alternative_name_a*.
+   The names of the constituent regions **must** refer to the **original** model native
+   region names. In the above example *region_a* and *region_b* and **not**
+   *alternative_name_a*.
 
-* *exclude_regions* optional (list of str): If input data for region processing
-  contains regions which are not mentioned in *native_regions*, in
-  *common_regions* (as the name of a common region or a constituent region) an
-  error will be raised. This is a safeguard against silently dropping regions
-  which are not in named in *native_regions* or *common_regions*. 
+* *exclude_regions* optional (list of str): If input data for region processing contains
+  regions which are not mentioned in *native_regions*, in *common_regions* (as the name
+  of a common region or a constituent region) an error will be raised. This is a
+  safeguard against silently dropping regions which are not in named in *native_regions*
+  or *common_regions*. 
   
-  If regions are to be excluded, they can be explicitly named in the
-  *exclude_regions* section which causes their presence to no longer raise an
-  error.
+  If regions are to be excluded, they can be explicitly named in the *exclude_regions*
+  section which causes their presence to no longer raise an error.
 
 
 Region aggregation
 ------------------
 
-In order to illustrate how region aggregation is performed, consider the
-following model mapping:
+In order to illustrate how region aggregation is performed, consider the following model
+mapping:
 
 .. code:: yaml
 
@@ -96,33 +93,19 @@ following model mapping:
        - region_a
        - region_b
 
-If the data provided for region aggregation contains results for
-*common_region_1* they are compared and combined according to the following
-logic:
+If the data provided for region aggregation contains results for *common_region_1* they
+are compared and combined according to the following logic:
 
-1. If a variable is **not** reported for *common_region_1*, it is calculated
-   through region aggregation of regions *region_a* and *region_b*.
-2. If a variable is **only** reported for *common_region_1* level it is used
-   directly.
+1. If a variable is **not** reported for *common_region_1*, it is calculated through
+   region aggregation of regions *region_a* and *region_b*.
+2. If a variable is **only** reported for *common_region_1* level it is used directly.
 3. If a variable is reported for *common_region_1* **as well as** *region_a* and
-   *region_b*. The **provided results** take **precedence** over the aggregated
-   ones. Additionally, the aggregation is computed and compared to the provided
-   results. If there are discrepancies, a warning is written to the logs.
+   *region_b*. The **provided results** take **precedence** over the aggregated ones.
+   Additionally, the aggregation is computed and compared to the provided results. If
+   there are discrepancies, a warning is written to the logs.
    
    .. note::
 
-      Please note that in case of differences no error is raised. Therefore it
-      is necessary to check the logs to find out if there were any differences.
-      This is intentional since some differences might be expected.
-
-.. _native-vs-common-region:
-
-Difference between model-native and common regions
----------------------------------------------------
-
-Model native regions are regions that are reported *directly* from an integrated
-assessment model. 
-
-Common regions, on the other hand, are calculated by *aggregating model native*
-regions. Common regions are used to compare results from models with different
-native regional resolution. 
+      Please note that in case of differences no error is raised. Therefore it is
+      necessary to check the logs to find out if there were any differences. This is
+      intentional since some differences might be expected.

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -19,14 +19,14 @@ Difference between model-native and common regions
 ---------------------------------------------------
 
 Model native regions are regions that are reported *directly* from an integrated
-assessment model. 
+assessment or energy system model.
 
 Common regions, on the other hand, are calculated by *aggregating* a model's *native*
 regions. Common regions are used to compare results from models with different native
 regional resolution. 
 
 As an example, let's say we have two models *model_a* and *model_b*. model_a reports
-native regions *Western* and *Eastern Europe* while *model_b* reports *Northern* and
+native regions *Western Europe* and *Eastern Europe* while *model_b* reports *Northern* and
 *Southern Europe*. In order to compare the results of the two models we might introduce
 a common region called *Europe*. 
 

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -115,11 +115,10 @@ logic:
       is necessary to check the logs to find out if there were any differences.
       This is intentional since some differences might be expected.
 
-Differences between model-native and common regions
----------------------------------------------------
+.. _native-vs-common-region:
 
-Understanding the differences between the two model concepts is essential in
-using the nomenclature package correctly. 
+Difference between model-native and common regions
+---------------------------------------------------
 
 Model native regions are regions that are reported *directly* from an integrated
 assessment model. 

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -3,16 +3,17 @@
 Region processing using model mappings
 ======================================
 
-Model mappings, defined on a per-model basis for region processing serve three different
-purposes:
+Model mappings, defined on a per-model basis for region processing serve three
+different purposes:
 
-1. Defining a list of model native regions under the key *native_regions* that are to be
-   selected (and usually uploaded) from an IAM result. This also serves as an implicit
-   exclusion list for model native regions, since only explicitly mentioned regions are
-   selected. Any region not mentioned in *native_regions* will cause an error unless explicitly named in the *exclude_regions* section. This to avoid accidentally forgetting a region.
+1. Defining a list of model native regions under the key *native_regions* that
+   are to be selected (and usually uploaded) from an IAM result. This also
+   serves as an implicit exclusion list for model native regions, since only
+   explicitly mentioned regions are selected. Any region not mentioned in
+   *native_regions* will cause an error unless explicitly named in the
+   *exclude_regions* section. This to avoid accidentally forgetting a region.
 2. Allowing for renaming of model native regions.
-3. Defining how model native regions should be aggregated to common
-   regions.
+3. Defining how model native regions should be aggregated to common regions.
 
 
 Model mapping format specification
@@ -52,39 +53,40 @@ This example illustrates how such a model mapping looks like:
   * *exclude_regions*
 
 *  *model* (str or list of str): the model name(s) for which the mapping applies.
-*  *native_regions* (list): a list of model native regions serves as
-   a selection as to which regions to keep.
+*  *native_regions* (list): a list of model native regions serves as a selection
+   as to which regions to keep.
 
-   *  In the above example *region_a* is to be renamed to
-      *alternative_name_a*. This is done by defining a key-value pair
-      of *model_native_name: new_name*.
+   *  In the above example *region_a* is to be renamed to *alternative_name_a*.
+      This is done by defining a key-value pair of *model_native_name:
+      new_name*.
    *  *region_b* is selected but the name is not changed.
-   *  Assuming *model_a* also defines a third region *region_c*,
-      since it is not mentioned it will be **dropped** from the data.
+   *  Assuming *model_a* also defines a third region *region_c*, since it is not
+      mentioned it will be **dropped** from the data.
 
-*  *common_regions* (list): list of common regions which will be computed as aggregates.
-   They are defined as list entries which themselves have a list of constituent regions.
-   These constituent regions must be model native regions.
+*  *common_regions* (list): list of common regions which will be computed as
+   aggregates. They are defined as list entries which themselves have a list of
+   constituent regions. These constituent regions must be model native regions.
 
-   The names of the constituent regions **must** refer to the **original** model native
-   region names. In the above example *region_a* and *region_b* and **not**
-   *alternative_name_a*.
+   The names of the constituent regions **must** refer to the **original** model
+   native region names. In the above example *region_a* and *region_b* and
+   **not** *alternative_name_a*.
 
-* *exclude_regions* optional (list of str): If input data for region processing contains
-  regions which are not mentioned in *native_regions*, in *common_regions* (as the name
-  of a common region or a constituent region) an error will be raised. This is a
-  safeguard against silently dropping regions which are not in named in *native_regions*
-  or *common_regions*. 
+* *exclude_regions* optional (list of str): If input data for region processing
+  contains regions which are not mentioned in *native_regions*, in
+  *common_regions* (as the name of a common region or a constituent region) an
+  error will be raised. This is a safeguard against silently dropping regions
+  which are not in named in *native_regions* or *common_regions*. 
   
-  If regions are to be excluded, they can be explicitly named in the *exclude_regions*
-  section which causes their presence to no longer raise an error.
+  If regions are to be excluded, they can be explicitly named in the
+  *exclude_regions* section which causes their presence to no longer raise an
+  error.
 
 
 Region aggregation
 ------------------
 
-In order to illustrate how region aggregation is performed, consider the following model
-mapping:
+In order to illustrate how region aggregation is performed, consider the
+following model mapping:
 
 .. code:: yaml
 
@@ -94,19 +96,21 @@ mapping:
        - region_a
        - region_b
 
-If the data provided for region aggregation contains results for *common_region_1* they
-are compared and combined according to the following logic:
+If the data provided for region aggregation contains results for
+*common_region_1* they are compared and combined according to the following
+logic:
 
-1. If a variable is **not** reported for *common_region_1*, it is calculated through
-   region aggregation of regions *region_a* and *region_b*.
-2. If a variable is **only** reported for *common_region_1* level it is used directly.
+1. If a variable is **not** reported for *common_region_1*, it is calculated
+   through region aggregation of regions *region_a* and *region_b*.
+2. If a variable is **only** reported for *common_region_1* level it is used
+   directly.
 3. If a variable is reported for *common_region_1* **as well as** *region_a* and
-   *region_b*. The **provided results** take **precedence** over the aggregated ones.
-   Additionally, the aggregation is computed and compared to the provided results. If
-   there are discrepancies, a warning is written to the logs.
+   *region_b*. The **provided results** take **precedence** over the aggregated
+   ones. Additionally, the aggregation is computed and compared to the provided
+   results. If there are discrepancies, a warning is written to the logs.
    
    .. note::
 
-      Please note that in case of differences no error is raised. Therefore it is
-      necessary to check the logs to find out if there were any differences. This is
-      intentional since some differences might be expected.
+      Please note that in case of differences no error is raised. Therefore it
+      is necessary to check the logs to find out if there were any differences.
+      This is intentional since some differences might be expected.

--- a/doc/source/user_guide/model-mapping.rst
+++ b/doc/source/user_guide/model-mapping.rst
@@ -114,3 +114,16 @@ logic:
       Please note that in case of differences no error is raised. Therefore it
       is necessary to check the logs to find out if there were any differences.
       This is intentional since some differences might be expected.
+
+Differences between model-native and common regions
+---------------------------------------------------
+
+Understanding the differences between the two model concepts is essential in
+using the nomenclature package correctly. 
+
+Model native regions are regions that are reported *directly* from an integrated
+assessment model. 
+
+Common regions, on the other hand, are calculated by *aggregating model native*
+regions. Common regions are used to compare results from models with different
+native regional resolution. 

--- a/doc/source/user_guide/model-registration.rst
+++ b/doc/source/user_guide/model-registration.rst
@@ -44,6 +44,8 @@ For this guide we will consider a model mapping as an example:
 ``model_a`` reports three regions natively, ``region_1``, ``region_2`` and ``region_3``.
 These three are to be renamed to the ``{model}|{region}`` pattern as is common place in
 many projects. For the ``common_regions``, there are ``World`` and ``Common region 1``.
+*For more details on the model native and common regions refer to*
+:ref:`native-vs-common-region`.
 
 Region definitions
 ^^^^^^^^^^^^^^^^^^

--- a/doc/source/user_guide/model-registration.rst
+++ b/doc/source/user_guide/model-registration.rst
@@ -44,7 +44,8 @@ For this guide we will consider a model mapping as an example:
 ``model_a`` reports three regions natively, ``region_1``, ``region_2`` and ``region_3``.
 These three are to be renamed to the ``{model}|{region}`` pattern as is common place in
 many projects. For the ``common_regions``, there are ``World`` and ``Common region 1``.
-*For more details on the model native and common regions refer to*
+
+*For more details on the model-native and common regions refer to*
 :ref:`native-vs-common-region`.
 
 Region definitions


### PR DESCRIPTION
closes #145.

As discussed, this PR adds a short section detailing the differences between model native and common regions. I have kept the explanation very minimal. Hope this work for clearing up confusion and giving people a quick explanation.

Looking forward to your comments.