### PR TITLE
Fix a bug casting Norway-ISO2-code "NO" to bool False

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -5,7 +5,7 @@ import pandas as pd
 import yaml
 from jsonschema import validate
 from pyam.utils import write_sheet
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, StrictBool
 
 from nomenclature.code import Code, Tag, replace_tags
 from nomenclature.error.codelist import DuplicateCodeError
@@ -54,7 +54,10 @@ class CodeList(BaseModel):
         List,
         Dict[
             str,
-            Union[Dict[str, Union[bool, str, float, int, list, dict, None]], List[str]],
+            Union[
+                Dict[str, Union[StrictBool, str, float, int, list, dict, None]],
+                List[str],
+            ],
         ],
     ] = {}
 

--- a/tests/data/norway_as_bool/regions.yaml
+++ b/tests/data/norway_as_bool/regions.yaml
@@ -1,0 +1,6 @@
+# guard against casting of 'NO' to boolean `False` by PyYAML or pydantic
+- countries:
+   - Norway:
+      eu_member: false
+      iso2: 'NO' # interpreted as 'false' without quotes
+      iso3: NOR

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -66,6 +66,13 @@ def test_region_codelist():
     assert code["Some Country"]["iso2"] == "XY"
 
 
+def test_norway_as_str():
+    """guard against casting of 'NO' to boolean `False` by PyYAML or pydantic"""
+    region = CodeList.from_directory("region", TEST_DATA_DIR / "norway_as_bool")
+    assert region["Norway"]["eu_member"] == False
+    assert region["Norway"]["iso2"] == "NO"
+
+
 def test_to_excel(tmpdir):
     """Check writing to xlsx"""
     file = tmpdir / "foo.xlsx"

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -69,7 +69,7 @@ def test_region_codelist():
 def test_norway_as_str():
     """guard against casting of 'NO' to boolean `False` by PyYAML or pydantic"""
     region = CodeList.from_directory("region", TEST_DATA_DIR / "norway_as_bool")
-    assert region["Norway"]["eu_member"] == False
+    assert region["Norway"]["eu_member"] is False
     assert region["Norway"]["iso2"] == "NO"
 
 


### PR DESCRIPTION
This PR fixes an issue reported by @HauHe (https://github.com/OSeMOSYS/osemosys2iamc/pull/23#discussion_r954992498) where the ISO2-code of Norway (NO) is cast to boolean `False` by **pydantic** instead of keeping it as a string.

fyi @willu47 & @tniet

