### PR TITLE
Codelist/region subclass

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -139,6 +139,8 @@ class CodeList(BaseModel):
             Directory with the codelist files
         file : str, optional
             Pattern to downselect codelist files by name
+        schema: str, optional
+            Schema to be used in the validation
 
         Returns
         -------
@@ -215,6 +217,8 @@ class CodeList(BaseModel):
             Directory with the codelist files
         file : str, optional
             Pattern to downselect codelist files by name
+        schema: str, optional
+            Schema to be used in the validation
 
         Returns
         -------

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -385,3 +385,35 @@ class VariableCodeList(CodeList):
                 ).mapping
 
         return v
+
+
+class RegionCodeList(CodeList):
+    """A subclass of CodeList specified for regions"""
+
+    @classmethod
+    def from_directory(
+        cls,
+        name: str,
+        path: Path,
+        file: str = None,
+    ):
+        """Initialize a VariableCodeList from a directory with codelist files
+
+        Parameters
+        ----------
+        _code_list : a region codelist
+
+        Returns
+        -------
+        RegionCodeList
+        """
+        _code_list = CodeList.parse_dir(name, path, file)
+
+        _region_code_list = []  # save refactored list as new (temporary) object
+        for top_level_cat in _code_list:
+            for top_key, _codes in top_level_cat.items():
+                for item in _codes:
+                    item = Code.from_dict(item)
+                    item.set_attribute("hierarchy", top_key)
+                    _region_code_list.append(item)
+        return cls(name=name, mapping=_region_code_list)

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -139,8 +139,6 @@ class CodeList(BaseModel):
             Directory with the codelist files
         file : str, optional
             Pattern to downselect codelist files by name
-        schema: str, optional
-            Schema to be used in the validation
 
         Returns
         -------
@@ -217,8 +215,6 @@ class CodeList(BaseModel):
             Directory with the codelist files
         file : str, optional
             Pattern to downselect codelist files by name
-        schema: str, optional
-            Schema to be used in the validation
 
         Returns
         -------

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -424,24 +424,21 @@ class RegionCodeList(CodeList):
             with open(yaml_file, "r", encoding="utf-8") as stream:
                 _code_list = yaml.safe_load(stream)
 
-            # process the files which do not start with tag
-            if not yaml_file.name.startswith("tag_"):
+            # a "region" codelist assumes a top-level key to be used as attribute
+            _region_code_list = []  # save refactored list as new (temporary) object
+            for top_level_cat in _code_list:
+                for top_key, _codes in top_level_cat.items():
+                    for item in _codes:
+                        item = Code.from_dict(item)
+                        item.set_attribute("hierarchy", top_key)
+                        _region_code_list.append(item)
+            _code_list = _region_code_list
 
-                # a "region" codelist assumes a top-level key to be used as attribute
-                _region_code_list = []  # save refactored list as new (temporary) object
-                for top_level_cat in _code_list:
-                    for top_key, _codes in top_level_cat.items():
-                        for item in _codes:
-                            item = Code.from_dict(item)
-                            item.set_attribute("hierarchy", top_key)
-                            _region_code_list.append(item)
-                _code_list = _region_code_list
-
-                # add `file` attribute to each element and add to main list
-                for item in _code_list:
-                    item.set_attribute(
-                        "file", yaml_file.relative_to(path.parent).as_posix()
-                    )
-                code_list.extend(_code_list)
+            # add `file` attribute to each element and add to main list
+            for item in _code_list:
+                item.set_attribute(
+                    "file", yaml_file.relative_to(path.parent).as_posix()
+                )
+            code_list.extend(_code_list)
 
         return cls(name=name, mapping=cls._parse_tags(code_list, path, file))

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -150,9 +150,11 @@ class CodeList(BaseModel):
         """
         tag_dict = CodeList(name="tag")
 
-        for yaml_file in (f for f in path.glob(file_glob_pattern)
-                          if f.suffix in {".yaml", ".yml"}
-                          and f.name.startswith("tag_")):
+        for yaml_file in (
+            f
+            for f in path.glob(file_glob_pattern)
+            if f.suffix in {".yaml", ".yml"} and f.name.startswith("tag_")
+        ):
             with open(yaml_file, "r", encoding="utf-8") as stream:
                 _code_list = yaml.safe_load(stream)
 
@@ -210,8 +212,9 @@ class CodeList(BaseModel):
                 )
             code_list.extend(_code_list)
 
-        return cls(name=name,
-                   mapping=cls._parse_tags(code_list, path, file_glob_pattern))
+        return cls(
+            name=name, mapping=cls._parse_tags(code_list, path, file_glob_pattern)
+        )
 
     @classmethod
     def read_excel(cls, name, source, sheet_name, col, attrs=[]):
@@ -436,5 +439,6 @@ class RegionCodeList(CodeList):
                 )
             code_list.extend(_code_list)
 
-        return cls(name=name,
-                   mapping=cls._parse_tags(code_list, path, file_glob_pattern))
+        return cls(
+            name=name, mapping=cls._parse_tags(code_list, path, file_glob_pattern)
+        )

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -7,11 +7,11 @@ from pyam.index import replace_index_labels
 from pyam.logging import adjust_log_level
 from pyam.utils import write_sheet
 
-from nomenclature.codelist import CodeList, VariableCodeList
+from nomenclature.codelist import CodeList, VariableCodeList, RegionCodeList
 from nomenclature.validation import validate
 
 logger = logging.getLogger(__name__)
-SPECIAL_CODELIST = {"variable": VariableCodeList}  # "region": RegionCodeList
+SPECIAL_CODELIST = {"variable": VariableCodeList, "region": RegionCodeList}
 
 
 class DataStructureDefinition:

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 import pandas as pd
 import pandas.testing as pdt
-from nomenclature.codelist import CodeList, VariableCodeList
+from nomenclature.codelist import CodeList, VariableCodeList, RegionCodeList
 from nomenclature.error.codelist import DuplicateCodeError
 
 from conftest import TEST_DATA_DIR
@@ -66,7 +66,7 @@ def test_tagged_codelist():
 
 def test_region_codelist():
     """Check replacing top-level hierarchy of yaml file as attribute for regions"""
-    code = CodeList.from_directory("region", TEST_DATA_DIR / "region_codelist")
+    code = RegionCodeList.from_directory("region", TEST_DATA_DIR / "region_codelist")
 
     assert "World" in code
     assert code["World"]["hierarchy"] == "common"
@@ -78,7 +78,7 @@ def test_region_codelist():
 
 def test_norway_as_str():
     """guard against casting of 'NO' to boolean `False` by PyYAML or pydantic"""
-    region = CodeList.from_directory("region", TEST_DATA_DIR / "norway_as_bool")
+    region = RegionCodeList.from_directory("region", TEST_DATA_DIR / "norway_as_bool")
     assert region["Norway"]["eu_member"] is False
     assert region["Norway"]["iso2"] == "NO"
 


### PR DESCRIPTION
Related to #137 

First attempt to split the functions to have the region specific part in RegionCodeList. I renamed `_parse_dir` to `_parse_tags` because it now focuses on tags and it is more understandable. 
There are anyways loops to parse the files in `_parse_tags()` **and** in `from_dir()`, it was what seemed to be the most understandable option to me, but I can change it... 