### PR TITLE
Fix RegionAggregationMapping.common_region_names docstring

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -263,7 +263,7 @@ class RegionAggregationMapping(BaseModel):
 
     @property
     def common_region_names(self) -> List[str]:
-        # List of the common regions
+        # List of the common region names
         return [x.name for x in self.common_regions or []]
 
     @property

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -263,7 +263,7 @@ class RegionAggregationMapping(BaseModel):
 
     @property
     def common_region_names(self) -> List[str]:
-        # List of the **original** model native region names
+        # List of the common regions
         return [x.name for x in self.common_regions or []]
 
     @property


### PR DESCRIPTION
Noticed yesterday that the docstring of the `RegionAggregationMapping.common_region_names` was wrong.