### PR TITLE
Quickfix to make yaml-check less stringent

### DIFF
--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -2,11 +2,12 @@ import yaml
 import logging
 from pathlib import Path
 from typing import List, Optional
-from string import printable
 
 import nomenclature
 
 logger = logging.getLogger(__name__)
+
+ILLEGAL_CHARS = ["\u202f"]
 
 
 def assert_valid_yaml(path: Path):
@@ -28,13 +29,13 @@ def assert_valid_yaml(path: Path):
             # check if any special character is found in the file
             for index, line in enumerate(all_lines.readlines()):
                 for col, char in enumerate(line):
-                    if char not in printable:
+                    if char in ILLEGAL_CHARS:
                         special_characters += (
                             f"\n - {file.name}, line {index + 1}, col {col + 1}. "
                         )
 
     if special_characters:
-        raise ValueError(f"Unexpected special character(s) in: {special_characters}")
+        raise AssertionError(f"Unexpected special character(s): {special_characters}")
 
     # test fails if any file cannot be parsed, raise error with list of these files
     if error:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -31,5 +31,5 @@ def test_assert_yaml_fails(caplog):
 def test_hidden_character():
     """Check that a non-printable character in any yaml file will raise an error"""
     match = "scenarios.yaml, line 3, col 12."
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(AssertionError, match=match):
         assert_valid_yaml(TEST_DATA_DIR / "hidden_character")


### PR DESCRIPTION
I just noticed that the newly added yaml-validation against illegal (hidden) characters is too stringent - in the openENTRANCE project, we have (valid) entries in the yaml files that are not "printable", like region names with special characters, see [this example](https://github.com/openENTRANCE/openentrance/blob/bc6a4fe490610246a9fe5cb7d47c95702ec54fd9/definitions/region/nuts1.yaml#L487).

This PR adapts the validation to only check against a list of specific illegal characters and changes the error type to AssertionError for consistency).

(We may need to add other illegal characters over time)