### PR TITLE
Add a `to_csv()` method

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -302,7 +302,7 @@ class CodeList(BaseModel):
         return codelist
 
     def to_csv(self, path=None, sort_by_code=False, **kwargs):
-        """Write the codelist to an Excel spreadsheet
+        """Write the codelist to a comma-separated values (csv) file
 
         Parameters
         ----------

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -280,12 +280,12 @@ class CodeList(BaseModel):
         else:
             return stream
 
-    def to_pandas(self, sorted: bool=False) -> pd.DataFrame:
+    def to_pandas(self, sort_by_code: bool = False) -> pd.DataFrame:
         """Export the CodeList to a :class:`pandas.DataFrame`
 
         Parameters
         ----------
-        sorted : bool, optional
+        sort_by_code : bool, optional
             Sort the codelist before exporting to csv.
         """
         codelist = (
@@ -294,14 +294,14 @@ class CodeList(BaseModel):
             .rename(columns={"index": self.name})
             .drop(columns="file")
         )
-        if sorted:
+        if sort_by_code:
             codelist.sort_values(by=self.name, inplace=True)
         codelist.rename(
             columns={c: str(c).capitalize() for c in codelist.columns}, inplace=True
         )
         return codelist
 
-    def to_csv(self, path=None, sort_by_code=False, **kwargs):
+    def to_csv(self, path=None, sort_by_code: bool = False, **kwargs):
         """Write the codelist to a comma-separated values (csv) file
 
         Parameters
@@ -314,10 +314,16 @@ class CodeList(BaseModel):
             Sort the codelist before exporting to csv.
         **kwargs
             Passed to :meth:`pandas.DataFrame.to_csv`.
+
+        Returns
+        -------
+        None or csv-formatted string (if *path* is None)
         """
         return self.to_pandas(sort_by_code).to_csv(path, **kwargs)
 
-    def to_excel(self, excel_writer, sheet_name=None, sort_by_code=False, **kwargs):
+    def to_excel(
+        self, excel_writer, sheet_name=None, sort_by_code: bool = False, **kwargs
+    ):
         """Write the codelist to an Excel spreadsheet
 
         Parameters

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -280,7 +280,7 @@ class CodeList(BaseModel):
         else:
             return stream
 
-    def to_pandas(self, sorted=False):
+    def to_pandas(self, sorted: bool=False) -> pd.DataFrame:
         """Export the CodeList to a :class:`pandas.DataFrame`
 
         Parameters

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -319,7 +319,8 @@ class CodeList(BaseModel):
         -------
         None or csv-formatted string (if *path* is None)
         """
-        return self.to_pandas(sort_by_code).to_csv(path, **kwargs)
+        index = kwargs.pop("index", False)  # by default, do not write index to csv
+        return self.to_pandas(sort_by_code).to_csv(path, index=index, **kwargs)
 
     def to_excel(
         self, excel_writer, sheet_name=None, sort_by_code: bool = False, **kwargs

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -330,7 +330,7 @@ class CodeList(BaseModel):
         sort_by_code : bool, optional
             Sort the codelist before exporting to file.
         **kwargs
-            Passed to :class:`pandas.ExcelWriter` (if *excel_writer* is path-like)
+            Passed to :class:`pandas.ExcelWriter` (if *excel_writer* is path-like).
         """
 
         # open a new ExcelWriter instance (if necessary)

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -317,9 +317,7 @@ class CodeList(BaseModel):
         """
         return self.to_pandas(sort_by_code).to_csv(path, **kwargs)
 
-    def to_excel(
-        self, excel_writer, sheet_name="definitions", sort_by_code=False, **kwargs
-    ):
+    def to_excel(self, excel_writer, sheet_name=None, sort_by_code=False, **kwargs):
         """Write the codelist to an Excel spreadsheet
 
         Parameters
@@ -327,13 +325,17 @@ class CodeList(BaseModel):
         excel_writer : path-like, file-like, or ExcelWriter object
             File path as string or :class:`pathlib.Path`,
             or existing :class:`pandas.ExcelWriter`.
-        sheet_name : str
-            Name of sheet that will contain the codelist.
+        sheet_name : str, optional
+            Name of sheet that will have the codelist. If *None*, use the codelist name.
         sort_by_code : bool, optional
             Sort the codelist before exporting to file.
         **kwargs
             Passed to :class:`pandas.ExcelWriter` (if *excel_writer* is path-like).
         """
+
+        # default sheet_name to the name of the codelist
+        if sheet_name is None:
+            sheet_name = self.name
 
         # open a new ExcelWriter instance (if necessary)
         close = False

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -317,7 +317,9 @@ class CodeList(BaseModel):
         """
         return self.to_pandas(sort_by_code).to_csv(path, **kwargs)
 
-    def to_excel(self, excel_writer, sheet_name="definitions", sort_by_code=False, **kwargs):
+    def to_excel(
+        self, excel_writer, sheet_name="definitions", sort_by_code=False, **kwargs
+    ):
         """Write the codelist to an Excel spreadsheet
 
         Parameters

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -119,7 +119,9 @@ class DataStructureDefinition:
             error = pd.concat(lst)
             return error if not error.empty else None
 
-    def to_excel(self, excel_writer, sheet_name=None, sort_by_code: bool = False, **kwargs):
+    def to_excel(
+        self, excel_writer, sheet_name=None, sort_by_code: bool = False, **kwargs
+    ):
         """Write the *variable* codelist to an Excel sheet
 
         Parameters

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -119,33 +119,20 @@ class DataStructureDefinition:
             error = pd.concat(lst)
             return error if not error.empty else None
 
-    def to_excel(self, excel_writer, sheet_name="variable_definitions"):
-        """Write the variable codelist to an Excel sheet
+    def to_excel(self, excel_writer, sheet_name=None, sort_by_code: bool = False, **kwargs):
+        """Write the *variable* codelist to an Excel sheet
 
         Parameters
         ----------
-        excel_writer : path-like, file-like, or :class:`pandas.ExcelWriter` object
-            File path or existing ExcelWriter.
+        excel_writer : path-like, file-like, or ExcelWriter object
+            File path as string or :class:`pathlib.Path`,
+            or existing :class:`pandas.ExcelWriter`.
         sheet_name : str, optional
-            Name of sheet which will contain the CodeList.
+            Name of sheet that will have the codelist. If *None*, use the codelist name.
+        sort_by_code : bool, optional
+            Sort the codelist before exporting to file.
+        **kwargs
+            Passed to :class:`pandas.ExcelWriter` (if *excel_writer* is path-like).
         """
-
-        close = False
-        if not isinstance(excel_writer, pd.ExcelWriter):
-            close = True
-            excel_writer = pd.ExcelWriter(excel_writer)
-
-        # write definitions to sheet
-        df = (
-            pd.DataFrame.from_dict(self.variable, orient="index")
-            .reset_index()
-            .rename(columns={"index": "variable"})
-            .drop(columns="file")
-        )
-        df.rename(columns={c: str(c).title() for c in df.columns}, inplace=True)
-
-        write_sheet(excel_writer, sheet_name, df)
-
-        # close the file if `excel_writer` arg was a file name
-        if close:
-            excel_writer.close()
+        # TODO write all dimensions to the file
+        self.variable.to_excel(excel_writer, sheet_name, sort_by_code, **kwargs)

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -106,7 +106,7 @@ def test_to_csv(sort):
         "Variable", TEST_DATA_DIR / "simple_codelist"
     ).to_csv(sort_by_code=sort, lineterminator="\n")
 
-    exp = ",Variable,Definition,Unit,Bool\n0,Some Variable,Some basic variable,,True\n"
+    exp = "Variable,Definition,Unit,Bool\nSome Variable,Some basic variable,,True\n"
     assert obs == exp
 
 

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -99,11 +99,12 @@ def test_to_excel(tmpdir):
     pdt.assert_frame_equal(obs, exp)
 
 
-def test_to_csv():
+@pytest.mark.parametrize("sort", (True, False))
+def test_to_csv(sort):
     """Check writing to csv"""
     obs = VariableCodeList.from_directory(
         "Variable", TEST_DATA_DIR / "simple_codelist"
-    ).to_csv(lineterminator="\n")
+    ).to_csv(sort_by_code=sort, lineterminator="\n")
 
     exp = ",Variable,Definition,Unit,Bool\n0,Some Variable,Some basic variable,,True\n"
     assert obs == exp

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -99,6 +99,16 @@ def test_to_excel(tmpdir):
     pdt.assert_frame_equal(obs, exp)
 
 
+def test_to_csv():
+    """Check writing to csv"""
+    obs = VariableCodeList.from_directory(
+        "Variable", TEST_DATA_DIR / "simple_codelist"
+    ).to_csv(lineterminator="\n")
+
+    exp = ",Variable,Definition,Unit,Bool\n0,Some Variable,Some basic variable,,True\n"
+    assert obs == exp
+
+
 def test_stray_tag_fails():
     """Check that typos in a tag raises expected error"""
 


### PR DESCRIPTION
Per a suggestion by @gunnar-pik at the NAVIGATE consortium meeting to have codelists as csv and then run a simple diff on them, this PR adds a `to_csv()` method (and also `to_pandas()` as a utility).

FYI @khaeru 