### PR TITLE
Simplify Code.attributes type hint

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -9,7 +9,7 @@ class Code(BaseModel):
 
     name: str
     description: Optional[str]
-    attributes: Dict[str, Any] = {}
+    extra_attributes: Dict[str, Any] = {}
 
     @classmethod
     def from_dict(cls, mapping) -> "Code":

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -9,7 +9,7 @@ class Code(BaseModel):
 
     name: str
     description: Optional[str]
-    attributes: Dict = {}
+    attributes: Dict[str, Any] = {}
 
     @classmethod
     def from_dict(cls, mapping) -> "Code":

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -8,24 +8,7 @@ class Code(BaseModel):
 
     name: str
     description: Optional[str]
-    attributes: Union[
-        Dict[
-            str,
-            Union[
-                StrictStr,
-                StrictInt,
-                StrictFloat,
-                StrictBool,
-                List,
-                None,
-                Dict[
-                    str,
-                    Union[StrictStr, StrictInt, StrictFloat, StrictBool, List, None],
-                ],
-            ],
-        ],
-        List[StrictStr],
-    ] = {}
+    attributes: Dict = {}
 
     @classmethod
     def from_dict(cls, mapping) -> "Code":

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -1,6 +1,7 @@
 import re
-from typing import Union, List, Dict, Optional, Set
-from pydantic import BaseModel, StrictStr, StrictInt, StrictFloat, StrictBool, Field
+from typing import Any, Dict, List, Optional, Set, Union
+
+from pydantic import BaseModel, Field
 
 
 class Code(BaseModel):


### PR DESCRIPTION
closes #191.

Mostly self explanatory, since `Code.attributes` does no longer need to support more complex region aggregation related data structures we can simplify the type hint.