### PR TITLE
Check names of additional attribute keys

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -12,7 +12,7 @@ class Code(BaseModel):
     description: Optional[str]
     extra_attributes: Dict[str, Any] = {}
 
-    @validator("attributes")
+    @validator("extra_attributes")
     def check_attribute_names(cls, v, values):
         # Check that attributes only contains keys which are valid identifiers
         if illegal_keys := [

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -1,6 +1,16 @@
 import re
-from typing import Union, List, Dict, Optional, Set
-from pydantic import BaseModel, StrictStr, StrictInt, StrictFloat, StrictBool, Field
+from keyword import iskeyword
+from typing import Dict, List, Optional, Set, Union
+
+from pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    validator,
+)
 
 
 class Code(BaseModel):
@@ -26,6 +36,18 @@ class Code(BaseModel):
         ],
         List[StrictStr],
     ] = {}
+
+    @validator("attributes")
+    def check_attribute_names(cls, v, values):
+        # Check that attributes only contains keys which are valid identifiers
+        if illegal_keys := [
+            key for key in v.keys() if not key.isidentifier() or iskeyword(key)
+        ]:
+            raise ValueError(
+                "Only valid identifiers are allowed as attribute keys. Found "
+                f"'{illegal_keys}' in '{values['name']}' which are not allowed."
+            )
+        return v
 
     @classmethod
     def from_dict(cls, mapping) -> "Code":

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nomenclature.code import VariableCode
+from nomenclature.code import Code, VariableCode
 
 
 def test_variable_without_unit_raises():
@@ -21,3 +21,9 @@ def test_variable_alias_setting():
         ).skip_region_aggregation
         is True
     )
+
+
+def test_illegal_additional_attribute():
+    match = "i'm not allowed.*'code1'.*not allowed"
+    with pytest.raises(ValueError, match=match):
+        Code(name="code1", attributes={"i'm not allowed": True})

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -23,7 +23,8 @@ def test_variable_alias_setting():
     )
 
 
-def test_illegal_additional_attribute():
-    match = "i'm not allowed.*'code1'.*not allowed"
+@pytest.mark.parametrize("illegal_key", ["contains-hyphen", "also not allowed", "True"])
+def test_illegal_additional_attribute(illegal_key):
+    match = f"{illegal_key}.*'code1'.*not allowed"
     with pytest.raises(ValueError, match=match):
-        Code(name="code1", attributes={"i'm not allowed": True})
+        Code(name="code1", attributes={illegal_key: True})

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -27,7 +27,7 @@ def test_variable_alias_setting():
 def test_illegal_additional_attribute(illegal_key):
     match = f"{illegal_key}.*'code1'.*not allowed"
     with pytest.raises(ValueError, match=match):
-        Code(name="code1", attributes={illegal_key: True})
+        Code(name="code1", extra_attributes={illegal_key: True})
 
 
 def test_variable_multiple_units():


### PR DESCRIPTION
Closes #190.

As discussed in #188, this PR adds a validator for the keys of `Code.attribute` and raises an error if any of them are not valid python identifiers or shadow keywords. 
Examples that are no longer allowed would be `"contains-hyphen"` or `"True".`