### PR TITLE
Apply tag replacing to named attributes as well

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -93,15 +93,19 @@ class Code(BaseModel):
         mapping = {
             key: value for key, value in self.dict().items() if key != "attributes"
         }
+        # replace name and description
         mapping["name"] = mapping["name"].replace("{" + tag + "}", target.name)
         mapping["description"] = mapping["description"].replace(
             "{" + tag + "}", target.description
         )
+
+        # replace any other attribute
         attributes = self.attributes.copy()
         for attr, value in target.attributes.items():
-            if attr in attributes:
+            if isinstance(attributes.get(attr), str):
                 attributes[attr] = attributes[attr].replace("{" + tag + "}", value)
-
+            elif isinstance(mapping.get(attr), str):
+                mapping[attr] = mapping[attr].replace("{" + tag + "}", value)
         return self.__class__(**mapping, attributes=attributes)
 
     def __getattr__(self, k):

--- a/tests/data/tagged_codelist/foo.yaml
+++ b/tests/data/tagged_codelist/foo.yaml
@@ -10,3 +10,4 @@
 - Final Energy|{Sector}|{Source}:
     definition: Final energy consumption of {Source} in the {Sector} sector
     unit: EJ
+    weight: Final Energy|{Sector}

--- a/tests/data/tagged_codelist/tag_sector.yaml
+++ b/tests/data/tagged_codelist/tag_sector.yaml
@@ -3,5 +3,7 @@
       definition: energy
       value_bool: true
       value_number: 2.3
+      weight: Energy
   - Industry:
       definition: industrial
+      weight: Energy


### PR DESCRIPTION
As changed in 70cbe0b3651a486d3fabdc52e3af2e0ed8be0347, the tag replacing would only be applied to `name`, `description` and additional attributes. 
This PR applies it to all string attributes found.
This should also fix openENTRANCE/openentrance#234.