### PR TITLE
Improve tag replacement

### DIFF
--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -50,7 +50,7 @@ to be used as tag. The files defining the tags must be named like ``tag_*.yaml``
      - Some Key:
          description: a short description of the key
 
-When importing a tagged codelist, code containing ``{Tag}`` in its name of a code will
+When importing a tagged codelist, any code containing ``{Tag}`` in its name will
 be replaced by the name of the corresponding tag. In addition any code attributes
 containing ``{Tag}`` will also be replaced. If the corresponding tag contains the attribute, this will be used for substitution, otherwise the tag name is used.
 

--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -50,10 +50,11 @@ to be used as tag. The files defining the tags must be named like ``tag_*.yaml``
      - Some Key:
          description: a short description of the key
 
-When importing a tagged codelist, any occurrence of ``{Tag}`` in the name of a code will
-be replaced by the corresponding element in the Tag dictionary. If the tag does not contain an element with ``{Tag}``, the tag name is used.
+When importing a tagged codelist, code containing ``{Tag}`` in its name of a code will
+be replaced by the name of the corresponding tag. In addition any code attributes
+containing ``{Tag}`` will also be replaced. If the corresponding tag contains the attribute, this will be used for substitution, otherwise the tag name is used.
 
-As an example, the following variable:
+To illustrate, consider the following variable:
 
 .. code:: yaml
 
@@ -62,7 +63,7 @@ As an example, the following variable:
       weight: {Tag}
 
 
-will be translated to:
+which will be translated to:
 
 .. code:: yaml
 
@@ -70,7 +71,8 @@ will be translated to:
       description: The description contains a short description of the key
       weight: Some Key
 
-Since the tag contains a *description* attribute is it replaced in the variable. 
+Since the tag contains a *description* attribute with value *a short description of the
+key* this is substituted in the *description* of the variable. 
 
-Additionally, the variable also contains the attribute *weight* which features
-``{Tag}``, which is not in the tag. In this case the tag name *Some Key* is used.
+In contrast, the variable contains the attribute *weight* which features ``{Tag}``,
+which is not present in the tag. In this case the tag name *Some Key* is used.

--- a/doc/source/user_guide/codelist.rst
+++ b/doc/source/user_guide/codelist.rst
@@ -51,5 +51,26 @@ to be used as tag. The files defining the tags must be named like ``tag_*.yaml``
          description: a short description of the key
 
 When importing a tagged codelist, any occurrence of ``{Tag}`` in the name of a code will
-be replaced by every element in the Tag dictionary. The ``{Tag}`` will also be replaced
-in any of the code attributes.
+be replaced by the corresponding element in the Tag dictionary. If the tag does not contain an element with ``{Tag}``, the tag name is used.
+
+As an example, the following variable:
+
+.. code:: yaml
+
+    - Variable|{Tag}:
+      description: The description contains {Tag}
+      weight: {Tag}
+
+
+will be translated to:
+
+.. code:: yaml
+
+    - Variable|Some Key:
+      description: The description contains a short description of the key
+      weight: Some Key
+
+Since the tag contains a *description* attribute is it replaced in the variable. 
+
+Additionally, the variable also contains the attribute *weight* which features
+``{Tag}``, which is not in the tag. In this case the tag name *Some Key* is used.

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -74,6 +74,13 @@ class Code(BaseModel):
     def tags(self):
         return re.findall("(?<={).*?(?=})", self.name)
 
+    @property
+    def flattened_dict(self):
+        return {
+            **{k: v for k, v in self.dict().items() if k != "attributes"},
+            **self.attributes,
+        }
+
     def replace_tag(self, tag: str, target: "Code") -> "Code":
         """Return a new instance with tag applied
 

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -362,11 +362,12 @@ class CodeList(BaseModel):
 
         nice_dict = {}
         for name, code in self.mapping.items():
-            code_dict = code.flattened_dict
-            del code_dict["name"]
-            for attr, value in code_dict.items():
-                if value is None and attr != "unit":
-                    del code_dict[attr]
+            code_dict = {
+                k: v
+                for k, v in code.flattened_dict.items()
+                if (v is not None and k != "name") or k == "unit"
+            }
+
             nice_dict[name] = code_dict
 
         return nice_dict

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -362,13 +362,11 @@ class CodeList(BaseModel):
 
         nice_dict = {}
         for name, code in self.mapping.items():
-            code_dict = code.dict()
+            code_dict = code.flattened_dict
             del code_dict["name"]
-            for attr, value in code.dict().items():
+            for attr, value in code_dict.items():
                 if value is None and attr != "unit":
                     del code_dict[attr]
-            code_dict.update(code_dict["attributes"])
-            del code_dict["attributes"]
             nice_dict[name] = code_dict
 
         return nice_dict

--- a/tests/data/tagged_codelist/tag_sector.yaml
+++ b/tests/data/tagged_codelist/tag_sector.yaml
@@ -1,8 +1,6 @@
 - Sector:
   - Energy:
       definition: energy
-      value_bool: true
-      value_number: 2.3
       weight: Energy
   - Industry:
       definition: industrial

--- a/tests/data/tagged_codelist/tag_sector.yaml
+++ b/tests/data/tagged_codelist/tag_sector.yaml
@@ -6,4 +6,3 @@
       weight: Energy
   - Industry:
       definition: industrial
-      weight: Energy

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -59,10 +59,21 @@ def test_tagged_codelist():
         "variable", TEST_DATA_DIR / "tagged_codelist"
     )
 
-    v = "Final Energy|Industry|Renewables"
-    d = "Final energy consumption of renewables in the industrial sector"
-    assert v in code
-    assert code[v].description == d
+    exp = {
+        "Final Energy|Industry|Renewables": {
+            "description": "Final energy consumption of renewables in the industrial sector",
+            "weight": "Final Energy|Industry",
+        },
+        "Final Energy|Energy|Renewables": {
+            "description": "Final energy consumption of renewables in the energy sector",
+            "weight": "Final Energy|Energy",
+        },
+    }
+
+    for code_name, attrs in exp.items():
+        assert code_name in code
+        for attr_name, value in attrs.items():
+            assert getattr(code[code_name], attr_name) == value
 
 
 def test_region_codelist():

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -61,11 +61,15 @@ def test_tagged_codelist():
 
     exp = {
         "Final Energy|Industry|Renewables": {
-            "description": "Final energy consumption of renewables in the industrial sector",
+            "description": (
+                "Final energy consumption of renewables in the industrial sector"
+            ),
             "weight": "Final Energy|Industry",
         },
         "Final Energy|Energy|Renewables": {
-            "description": "Final energy consumption of renewables in the energy sector",
+            "description": (
+                "Final energy consumption of renewables in the energy sector"
+            ),
             "weight": "Final Energy|Energy",
         },
     }


### PR DESCRIPTION
This PR implements an improved tag replacement logic. 
The new logic is:
* Find all occurrences of `"{tag}"`
* If the tag has the same attribute as the base code, replace the value of the attribute
* If the tag does not have the same attribute, replace with the name of the tag. 

Also, since I added the property `Code.flattened_dict` I also made sure to use it in `CodeList.codelist_repr`.