### PR TITLE
Clean up imports

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -1,15 +1,17 @@
 import logging
-from pathlib import Path
-from setuptools_scm import get_version
 from importlib.metadata import version
+from pathlib import Path
 
-from nomenclature.core import process  # noqa
-from nomenclature.codelist import CodeList  # noqa
-from nomenclature.definition import DataStructureDefinition, SPECIAL_CODELIST  # noqa
+from setuptools_scm import get_version
+
 from nomenclature.cli import cli  # noqa
-from nomenclature.processor.region import (  # noqa
+from nomenclature.codelist import CodeList  # noqa
+from nomenclature.core import process  # noqa
+from nomenclature.definition import SPECIAL_CODELIST, DataStructureDefinition  # noqa
+from nomenclature.processor import (
+    RegionAggregationMapping,  # noqa
     RegionProcessor,
-    RegionAggregationMapping,
+    RequiredDataProcessor,
 )
 
 # set up logging

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -8,10 +8,9 @@ from nomenclature.cli import cli  # noqa
 from nomenclature.codelist import CodeList  # noqa
 from nomenclature.core import process  # noqa
 from nomenclature.definition import SPECIAL_CODELIST, DataStructureDefinition  # noqa
-from nomenclature.processor import (
-    RegionAggregationMapping,  # noqa
+from nomenclature.processor import (  # noqa
+    RegionAggregationMapping,
     RegionProcessor,
-    RequiredDataProcessor,
 )
 
 # set up logging

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -1,9 +1,10 @@
-import click
 import ast
 from pathlib import Path
 from typing import List, Optional
 
-from nomenclature.testing import assert_valid_yaml, assert_valid_structure
+import click
+
+from nomenclature.testing import assert_valid_structure, assert_valid_yaml
 
 cli = click.Group()
 

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -1,12 +1,11 @@
 from pathlib import Path
-from typing import Dict, List, ClassVar
+from typing import ClassVar, Dict, List
 
 import pandas as pd
 import yaml
 from jsonschema import validate
 from pyam.utils import write_sheet
 from pydantic import BaseModel, validator
-
 
 from nomenclature.code import Code, VariableCode
 from nomenclature.error.codelist import DuplicateCodeError

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -6,7 +6,7 @@ import pyam
 from pydantic import validate_arguments
 
 from nomenclature.definition import DataStructureDefinition
-from nomenclature.processor.region import RegionProcessor
+from nomenclature.processor import RegionProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -1,12 +1,12 @@
-import pandas as pd
 import logging
 from pathlib import Path
 
+import pandas as pd
 from pyam import IamDataFrame
 from pyam.index import replace_index_labels
 from pyam.logging import adjust_log_level
 
-from nomenclature.codelist import CodeList, VariableCodeList, RegionCodeList
+from nomenclature.codelist import CodeList, RegionCodeList, VariableCodeList
 from nomenclature.validation import validate
 
 logger = logging.getLogger(__name__)

--- a/nomenclature/processor/__init__.py
+++ b/nomenclature/processor/__init__.py
@@ -3,4 +3,3 @@ from nomenclature.processor.region import (  # noqa
     RegionAggregationMapping,
     RegionProcessor,
 )
-from nomenclature.processor.requiredData import RequiredDataProcessor  # noqa

--- a/nomenclature/processor/__init__.py
+++ b/nomenclature/processor/__init__.py
@@ -1,0 +1,6 @@
+from nomenclature.processor.processor import Processor  # noqa
+from nomenclature.processor.region import (  # noqa
+    RegionAggregationMapping,
+    RegionProcessor,
+)
+from nomenclature.processor.requiredData import RequiredDataProcessor  # noqa

--- a/nomenclature/processor/__init__.py
+++ b/nomenclature/processor/__init__.py
@@ -1,4 +1,3 @@
-from nomenclature.processor.processor import Processor  # noqa
 from nomenclature.processor.region import (  # noqa
     RegionAggregationMapping,
     RegionProcessor,

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -7,20 +7,21 @@ import jsonschema
 import pyam
 import pydantic
 import yaml
-from nomenclature.codelist import PYAM_AGG_KWARGS
-from nomenclature.definition import DataStructureDefinition
-from nomenclature.error.region import (
-    ModelMappingCollisionError,
-    RegionNameCollisionError,
-    RegionNotDefinedError,
-    ExcludeRegionOverlapError,
-)
-from nomenclature.processor.utils import get_relative_path
 from pyam import IamDataFrame
 from pyam.logging import adjust_log_level
 from pydantic import BaseModel, root_validator, validate_arguments, validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.types import DirectoryPath, FilePath
+
+from nomenclature.codelist import PYAM_AGG_KWARGS
+from nomenclature.definition import DataStructureDefinition
+from nomenclature.error.region import (
+    ExcludeRegionOverlapError,
+    ModelMappingCollisionError,
+    RegionNameCollisionError,
+    RegionNotDefinedError,
+)
+from nomenclature.processor.utils import get_relative_path
 
 AGG_KWARGS = PYAM_AGG_KWARGS + ["region_aggregation"]
 

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -1,9 +1,11 @@
-import yaml
 import logging
 from pathlib import Path
 from typing import List, Optional
 
-import nomenclature
+import yaml
+
+from nomenclature.definition import DataStructureDefinition
+from nomenclature.processor import RegionProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -87,16 +89,14 @@ def assert_valid_structure(
                 f"`definitions` directory is empty: {path / definitions}"
             )
 
-    definition = nomenclature.DataStructureDefinition(path / definitions, dimensions)
+    definition = DataStructureDefinition(path / definitions, dimensions)
     if mappings is None:
         if (path / "mappings").is_dir():
-            nomenclature.RegionProcessor.from_directory(
-                path / "mappings"
-            ).validate_mappings(definition)
+            RegionProcessor.from_directory(path / "mappings").validate_mappings(
+                definition
+            )
     elif (path / mappings).is_dir():
-        nomenclature.RegionProcessor.from_directory(path / mappings).validate_mappings(
-            definition
-        )
+        RegionProcessor.from_directory(path / mappings).validate_mappings(definition)
     else:
         raise FileNotFoundError(f"Mappings directory not found: {path / mappings}")
 


### PR DESCRIPTION
As I was working on #205 I made some changes to the imports as `processor` is now getting to a place where it makes sense to make it into a proper sub module.
In order to keep #205 minimal I took out all the clean up of the imports into this PR.

Changes include order of imports, order within imports and making inner module imports consistent.