### PR TITLE
Improve readability of illegal unit error

### DIFF
--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -50,7 +50,8 @@ def validate(dsd, df, dimensions):
                 f"'{e}', found: '{u}'"
                 for v, u, e in invalid_units
             ]
-            log_error("variable", lst)
+            msg = "The following items are reported with the wrong unit:"
+            logger.error("\n - ".join([msg] + lst))
             error = True
 
     # validation of all other dimensions

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -50,7 +50,7 @@ def validate(dsd, df, dimensions):
                 f"'{e}', found: '{u}'"
                 for v, u, e in invalid_units
             ]
-            msg = "The following items are reported with the wrong unit:"
+            msg = "The following variable(s) are reported with the wrong unit:"
             logger.error("\n - ".join([msg] + lst))
             error = True
 

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -45,7 +45,9 @@ def validate(dsd, df, dimensions):
             error = True
 
         if invalid_units:
-            lst = [f"{v} - expected: {e}, found: {u}" for v, u, e in invalid_units]
+            lst = [
+                f"'{v}' - expected: '{e}', found: '{u}'" for v, u, e in invalid_units
+            ]
             log_error("variable", lst)
             error = True
 

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -46,7 +46,9 @@ def validate(dsd, df, dimensions):
 
         if invalid_units:
             lst = [
-                f"'{v}' - expected: '{e}', found: '{u}'" for v, u, e in invalid_units
+                f"'{v}' - expected: {'one of ' if isinstance(e, list) else ''}"
+                f"'{e}', found: '{u}'"
+                for v, u, e in invalid_units
             ]
             log_error("variable", lst)
             error = True


### PR DESCRIPTION
Currently illegal unit errors are a little hard to read, adding some quotes should make it a bit easier especially for variables and units containing spaces.

This PR changes these errors from:

```console
The following items are not defined in the 'variable' codelist:
- Capital Cost|Electricity|Biomass|w/ CCS - expected: US$2010/kW, found: US$2010/kW OR local currency/kW
```
to:

```console
The following items are not defined in the 'variable' codelist:
- 'Capital Cost|Electricity|Biomass|w/ CCS' - expected: 'US$2010/kW', found: 'US$2010/kW OR local currency/kW'
```
