### PR TITLE
Refactor RegionProcessor apply interface

### DIFF
--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -62,11 +62,11 @@ def process(
         if "region" in dimensions:
             dimensions.remove("region")
             dsd.validate(df, dimensions=dimensions)
-            df = processor.apply(df, dsd)
+            df = processor.apply(df)
             dsd.validate(df, dimensions=["region"])
         else:
             dsd.validate(df, dimensions=dimensions)
-            df = processor.apply(df, dsd)
+            df = processor.apply(df)
 
     # check consistency across the variable hierarchy
     error = dsd.check_aggregate(df)

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -285,10 +285,9 @@ class RegionAggregationMapping(BaseModel):
     def rename_mapping(self) -> Dict[str, str]:
         return {r.name: r.target_native_region for r in self.native_regions or []}
 
-    def validate_regions(self, dsd: DataStructureDefinition) -> None:
-        if hasattr(dsd, "region"):
-            if invalid := dsd.region.validate_items(self.all_regions):
-                raise RegionNotDefinedError(region=invalid, file=self.file)
+    def validate_regions(self, region_codelist: RegionCodeList) -> None:
+        if invalid := region_codelist.validate_items(self.all_regions):
+            raise RegionNotDefinedError(region=invalid, file=self.file)
 
     def check_unexpected_regions(self, df: IamDataFrame) -> None:
         # Raise error if a region in the input data is not used in the model mapping

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, root_validator, validate_arguments, validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.types import DirectoryPath, FilePath
 
+from nomenclature.codelist import RegionCodeList, VariableCodeList
 from nomenclature.definition import DataStructureDefinition
 from nomenclature.error.region import (
     ExcludeRegionOverlapError,
@@ -314,17 +315,22 @@ class RegionAggregationMapping(BaseModel):
 class RegionProcessor(BaseModel):
     """Region aggregation mappings for scenario processing"""
 
+    region_codelist: RegionCodeList
+    variable_codelist: VariableCodeList
     mappings: Dict[str, RegionAggregationMapping]
 
     @classmethod
-    @validate_arguments
-    def from_directory(cls, path: DirectoryPath):
+    @validate_arguments(config={"arbitrary_types_allowed": True})
+    def from_directory(cls, path: DirectoryPath, dsd: DataStructureDefinition):
         """Initialize a RegionProcessor from a directory of model-aggregation mappings.
 
         Parameters
         ----------
         path : DirectoryPath
             Directory which holds all the mappings.
+        dsd : DataStructureDefinition
+            Instance of DataStructureDefinition used for validation of mappings and
+            region aggregation.
 
         Returns
         -------

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -56,11 +56,9 @@ def _check_mappings(
     dsd = DataStructureDefinition(path / definitions, dimensions)
     if mappings is None:
         if (path / "mappings").is_dir():
-            RegionProcessor.from_directory(path / "mappings").validate_with_definition(
-                dsd
-            )
+            RegionProcessor.from_directory(path / "mappings", dsd)
     elif (path / mappings).is_dir():
-        RegionProcessor.from_directory(path / mappings).validate_with_definition(dsd)
+        RegionProcessor.from_directory(path / mappings, dsd)
     else:
         raise FileNotFoundError(f"Mappings directory not found: {path / mappings}")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,9 +39,9 @@ def test_region_processing_rename(model_name):
 
     obs = process(
         test_df,
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+        dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/rename_only"
+            TEST_DATA_DIR / "region_processing/rename_only", dsd
         ),
     )
 
@@ -67,8 +67,8 @@ def test_region_processing_empty_raises(rp_dir):
     with pytest.raises(ValueError, match=("'model_a', 'model_b'.*empty dataset")):
         process(
             test_df,
-            DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
-            processor=RegionProcessor.from_directory(TEST_DATA_DIR / rp_dir),
+            dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+            processor=RegionProcessor.from_directory(TEST_DATA_DIR / rp_dir, dsd),
         )
 
 
@@ -79,9 +79,9 @@ def test_region_processing_no_mapping(simple_df):
 
     obs = process(
         simple_df,
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+        dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/no_mapping"
+            TEST_DATA_DIR / "region_processing/no_mapping", dsd
         ),
     )
     assert_iamframe_equal(obs, exp)
@@ -113,9 +113,9 @@ def test_region_processing_aggregate():
 
     obs = process(
         test_df,
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+        dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/aggregate_only"
+            TEST_DATA_DIR / "region_processing/aggregate_only", dsd
         ),
     )
 
@@ -161,9 +161,9 @@ def test_region_processing_complete(directory):
 
     obs = process(
         test_df,
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+        dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing" / directory
+            TEST_DATA_DIR / "region_processing" / directory, dsd
         ),
     )
     assert_iamframe_equal(obs, exp)
@@ -227,9 +227,11 @@ def test_region_processing_weighted_aggregation(folder, exp_df, args, caplog):
 
     obs = process(
         test_df,
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing" / folder / "dsd"),
+        dsd := DataStructureDefinition(
+            TEST_DATA_DIR / "region_processing" / folder / "dsd"
+        ),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing" / folder / "aggregate"
+            TEST_DATA_DIR / "region_processing" / folder / "aggregate", dsd
         ),
     )
     assert_iamframe_equal(obs, exp)
@@ -272,11 +274,11 @@ def test_region_processing_skip_aggregation(model_name, region_names):
 
     obs = process(
         input_df,
-        DataStructureDefinition(
+        dsd := DataStructureDefinition(
             TEST_DATA_DIR / "region_processing/skip_aggregation/dsd"
         ),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/skip_aggregation/mappings"
+            TEST_DATA_DIR / "region_processing/skip_aggregation/mappings", dsd
         ),
     )
     assert_iamframe_equal(obs, exp)
@@ -383,9 +385,9 @@ def test_partial_aggregation(input_data, exp_data, warning, caplog):
 
     obs = process(
         IamDataFrame(pd.DataFrame(input_data, columns=IAMC_IDX + [2005, 2010])),
-        DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+        dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
         processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/partial_aggregation"
+            TEST_DATA_DIR / "region_processing/partial_aggregation", dsd
         ),
     )
     exp = IamDataFrame(pd.DataFrame(exp_data, columns=IAMC_IDX + [2005, 2010]))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,13 +37,11 @@ def test_region_processing_rename(model_name):
     exp.filter(region=["region_a", "region_B"], inplace=True)
     exp.rename(region={"region_a": "region_A"}, inplace=True)
 
-    obs = process(
-        test_df,
-        dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
-        processor=RegionProcessor.from_directory(
-            TEST_DATA_DIR / "region_processing/rename_only", dsd
-        ),
+    dsd = DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd")
+    region_processor = RegionProcessor.from_directory(
+        TEST_DATA_DIR / "region_processing/rename_only", dsd
     )
+    obs = process(test_df, dsd, processor=region_processor)
 
     assert_iamframe_equal(obs, exp)
 

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -108,9 +108,9 @@ def test_illegal_mappings(file, error_type, error_msg_pattern):
         (TEST_DATA_DIR / "regionprocessor_working").relative_to(Path.cwd()),
     ],
 )
-def test_region_processor_working(region_processor_path):
+def test_region_processor_working(region_processor_path, simple_definition):
 
-    obs = RegionProcessor.from_directory(region_processor_path)
+    obs = RegionProcessor.from_directory(region_processor_path, simple_definition)
     exp_data = [
         {
             "model": ["model_a"],
@@ -155,14 +155,16 @@ def test_region_processor_not_defined(simple_definition):
     )
     with pytest.raises(pydantic.ValidationError, match=error_msg):
         RegionProcessor.from_directory(
-            TEST_DATA_DIR / "regionprocessor_not_defined"
-        ).validate_with_definition(simple_definition)
+            TEST_DATA_DIR / "regionprocessor_not_defined", simple_definition
+        )
 
 
-def test_region_processor_duplicate_model_mapping():
+def test_region_processor_duplicate_model_mapping(simple_definition):
     error_msg = ".*model_a.*mapping_(1|2).yaml.*mapping_(1|2).yaml"
     with pytest.raises(pydantic.ValidationError, match=error_msg):
-        RegionProcessor.from_directory(TEST_DATA_DIR / "regionprocessor_duplicate")
+        RegionProcessor.from_directory(
+            TEST_DATA_DIR / "regionprocessor_duplicate", simple_definition
+        )
 
 
 def test_region_processor_wrong_args():
@@ -182,15 +184,17 @@ def test_region_processor_wrong_args():
         )
 
 
-def test_region_processor_multiple_wrong_mappings():
+def test_region_processor_multiple_wrong_mappings(simple_definition):
     # Read in the entire region_aggregation directory and return **all** errors
     msg = "9 validation errors for RegionProcessor"
 
     with pytest.raises(pydantic.ValidationError, match=msg):
-        RegionProcessor.from_directory(TEST_DATA_DIR / "region_aggregation")
+        RegionProcessor.from_directory(
+            TEST_DATA_DIR / "region_aggregation", simple_definition
+        )
 
 
-def test_region_processor_exclude_model_native_overlap_raises():
+def test_region_processor_exclude_model_native_overlap_raises(simple_definition):
     # Test that exclude regions in either native or common regions raise errors
 
     with pytest.raises(
@@ -201,7 +205,7 @@ def test_region_processor_exclude_model_native_overlap_raises():
         ),
     ):
         RegionProcessor.from_directory(
-            TEST_DATA_DIR / "regionprocessor_exclude_region_overlap"
+            TEST_DATA_DIR / "regionprocessor_exclude_region_overlap", simple_definition
         )
 
 
@@ -219,8 +223,8 @@ def test_region_processor_unexpected_region_raises():
     with pytest.raises(ValueError, match="Did not find.*'region_B'.*in.*model_a.yaml"):
         process(
             test_df,
-            DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
+            dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
             processor=RegionProcessor.from_directory(
-                TEST_DATA_DIR / "regionprocessor_unexpected_region"
+                TEST_DATA_DIR / "regionprocessor_unexpected_region", dsd
             ),
         )


### PR DESCRIPTION
Addresses first point in #215.

As per discussion yesterday this PR is the first step towards allowing `process` to take a list of `Processor` instances. There are more steps required but I opted to go for multiple PRs to keep them on the smaller side. 

### Implemented changes

* `RegionProcessor.apply()` now only takes a `pyam.IamDataFrame` instance as an input as opposed to also needing a `DataStructureDefinition`.
* Instead the `DataStructureDefinition` is now handed to the `RegionProcessor` at creation as part of the `from_directory()` classmethod. I opted to go for fully instantiated `DataStructureDefinition` instead of a path to the definitions directory so that any errors that may occur related to the `DataStructureDefinition` not being valid, occur before the `RegionProcessor` can be instantiated. I.e. I opted for:

```python
dsd = DataStructureDefinition("definitions/") # error occurs here
rp = RegionProcessor("mappings/", dsd)
```
instead of:

```python
# error related to DataStructureDefinition would still occur in RegionProcessor
# which is less straightforward to read
rp = RegionProcessor("mappings/", "definitions/") 
```

* I chose to not include the entire `DataStructureDefinition` in the `RegionProcessor` class but only the required RegionCodeList and VariableCodeList to keep the class to the required minimum of information needed.
* Since the `RegionProcessor` object now contains codelists the `validate_with_definition` method no longer needs a `DataStructureDefinition` as input. Therefore I made it into a proper pydantic validator that is always executed at object creation. 

### Open questions/considerations

* I included a check for the provided `DataStructureDefinition` in `RegionProcessor.from_directory` for the required variable and region codelists. An error is raised if either is missing. Technically, this is a slight deviation from the previous implementation. Previously if no region codelist was given not error was thrown and region validation was simply skipped. I could of course change it back to the old style but I think the case where we have a `RegionProcessor` but no region codelist either does not exist or should be avoided anyway.

* Since `RegionProcessor.validate_with_definition` is now a pydantic validator it is called upon object creation. This means that a faulty model mapping will cause an upload to crash. This will be the case even if the faulty model mapping applies to a different model than is in the upload. This can also be changed back but since we have integration tests in place anyway this case should not occur. I can also revert it back to the old style though.

* Merging this PR into `main` would crash all current project workflows using region processing as the `RegionProcessor` now needs to be instantiated with a `DataStructureDefinition`. This is of course not a problem, I could simply update them all but this PR is part of a set of planned PRs that will change the interface of at least the `process` function as well. So in order to avoid updating all workflows after merging this PR and then doing essentially the same thing again I was wondering if it might be a good idea to create a temporary `dev` branch where I'd merge all PRs that concern the implementation of the new processing pipeline and once it's all done I only have to update all the workflows once.

Looking forward to your input @danielhuppmann.