### PR TITLE
Fix a bug where meta-indicators are dropped during region-processing

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -553,7 +553,8 @@ def _merge_with_provided_data(
 
     # merge aggregated data onto original common-region data
     index = aggregate_df._data.index.difference(common_region_df._data.index)
-    return common_region_df.append(aggregate_df._data[index])
+    aggregate_df = pyam.IamDataFrame(aggregate_df._data[index], meta=aggregate_df.meta)
+    return common_region_df.append(aggregate_df)
 
 
 def _check_exclude_region_overlap(values: Dict, region_type: str) -> Dict:

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -543,7 +543,7 @@ def _aggregate_region(df, var, *regions, **kwargs):
             raise e
 
 
-def _compare_and_merge(original: pd.Series, aggregated: pd.Series, ) -> IamDataFrame:
+def _compare_and_merge(original: pd.Series, aggregated: pd.Series) -> IamDataFrame:
     """Compare and merge original and aggregated results"""
 
     # compare processed (aggregated) data and data provided at the common-region level

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -438,7 +438,9 @@ class RegionProcessor(BaseModel):
                         )
                         if not _df.empty:
                             _processed_data.append(
-                                _df.rename(region=self.mappings[model].rename_mapping)._data
+                                _df.rename(
+                                    region=self.mappings[model].rename_mapping
+                                )._data
                             )
 
                     # Aggregate
@@ -449,8 +451,8 @@ class RegionProcessor(BaseModel):
                             # native region, just rename
                             if cr.is_single_constituent_region:
                                 _df = model_df.filter(
-                                        region=cr.constituent_regions[0]
-                                    ).rename(region=cr.rename_dict)
+                                    region=cr.constituent_regions[0]
+                                ).rename(region=cr.rename_dict)
                                 if not _df.empty:
                                     _processed_data.append(_df._data)
                                 continue
@@ -466,9 +468,9 @@ class RegionProcessor(BaseModel):
                                 )
                             ]
                             _df = model_df.aggregate_region(
-                                    simple_vars,
-                                    *regions,
-                                )
+                                simple_vars,
+                                *regions,
+                            )
                             if _df is not None and not _df.empty:
                                 _processed_data.append(_df._data)
 

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -410,7 +410,7 @@ class RegionProcessor(BaseModel):
 
             # If no mapping is defined the data frame is returned unchanged
             if model not in self.mappings:
-                logger.info(f"No model mapping found for model {model}")
+                logger.info(f"No model mapping found for model '{model}'")
                 processed_dfs.append(model_df)
 
             # Otherwise we first rename, then aggregate
@@ -418,7 +418,7 @@ class RegionProcessor(BaseModel):
                 # before aggregating, check that all regions are valid
                 self.mappings[model].validate_regions(self.region_codelist)
                 logger.info(
-                    f"Applying region-processing for model {model} from file "
+                    f"Applying region-processing for model '{model}' from file "
                     f"{self.mappings[model].file}"
                 )
                 # Check for regions not mentioned in the model mapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,10 +42,10 @@ def simple_df():
 def add_meta(df):
     """Add simple meta indicators"""
     if len(df.index) == 1:
-        df.set_meta([1], "number")
+        df.set_meta([1.], "number")
         df.set_meta(["foo"], "string")
     if len(df.index) == 2:
-        df.set_meta([1, 2], "number")
+        df.set_meta([1., 2.], "number")
         df.set_meta(["foo", np.nan], "string")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,10 +42,10 @@ def simple_df():
 def add_meta(df):
     """Add simple meta indicators"""
     if len(df.index) == 1:
-        df.set_meta([1.], "number")
+        df.set_meta([1.0], "number")
         df.set_meta(["foo"], "string")
     if len(df.index) == 2:
-        df.set_meta([1., 2.], "number")
+        df.set_meta([1.0, 2.0], "number")
         df.set_meta(["foo", np.nan], "string")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Dict, List
 import pytest
+import numpy as np
 import pandas as pd
 from pyam import IamDataFrame, IAMC_IDX
 from nomenclature import DataStructureDefinition
@@ -33,7 +34,19 @@ def extras_definition():
 
 @pytest.fixture(scope="function")
 def simple_df():
-    yield IamDataFrame(TEST_DF)
+    df = IamDataFrame(TEST_DF)
+    add_meta(df)
+    yield df
+
+
+def add_meta(df):
+    """Add simple meta indicators"""
+    if len(df.index) == 1:
+        df.set_meta([1], "number")
+        df.set_meta(["foo"], "string")
+    if len(df.index) == 2:
+        df.set_meta([1, 2], "number")
+        df.set_meta(["foo", np.nan], "string")
 
 
 def remove_file_from_mapping(mapping: Dict[str, Code]) -> List[Dict]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -363,8 +363,7 @@ def test_region_processing_skip_aggregation(model_name, region_names):
             [["m_a", "s_a", "World", "Primary Energy", "EJ/yr", 5, 6]],
             [
                 "Difference between original and aggregated data:",
-                "m_a   s_a      World  Primary Energy",
-                "2005              5            4",
+                "m_a   s_a      World  Primary Energy EJ/yr 2005         5           4",
             ],
         ),
         (  # Conflict between overlapping renamed variable and provided data
@@ -376,8 +375,7 @@ def test_region_processing_skip_aggregation(model_name, region_names):
             [["m_a", "s_a", "World", "Variable B", "EJ/yr", 4, 6]],
             [
                 "Difference between original and aggregated data:",
-                "m_a   s_a      World  Variable B EJ/yr",
-                "2005              4            3",
+                "m_a   s_a      World  Variable B EJ/yr 2005         4           3",
             ],
         ),
     ],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ from nomenclature.definition import DataStructureDefinition
 from nomenclature.processor.region import RegionProcessor
 from pyam import IAMC_IDX, IamDataFrame, assert_iamframe_equal
 
-from conftest import TEST_DATA_DIR
+from conftest import TEST_DATA_DIR, add_meta
 
 
 @pytest.mark.parametrize("model_name", ["model_a", "model_c"])
@@ -32,6 +32,7 @@ def test_region_processing_rename(model_name):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(test_df)
 
     exp = copy.deepcopy(test_df)
     exp.filter(region=["region_a", "region_B"], inplace=True)
@@ -99,6 +100,8 @@ def test_region_processing_aggregate():
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(test_df)
+
     exp = IamDataFrame(
         pd.DataFrame(
             [
@@ -108,6 +111,7 @@ def test_region_processing_aggregate():
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(exp)
 
     obs = process(
         test_df,
@@ -142,6 +146,8 @@ def test_region_processing_complete(directory):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(test_df)
+
     exp = IamDataFrame(
         pd.DataFrame(
             [
@@ -156,6 +162,7 @@ def test_region_processing_complete(directory):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(exp)
 
     obs = process(
         test_df,
@@ -217,11 +224,13 @@ def test_region_processing_weighted_aggregation(folder, exp_df, args, caplog):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(test_df)
 
     if args is not None:
         test_df = test_df.filter(**args)
 
     exp = IamDataFrame(pd.DataFrame(exp_df, columns=IAMC_IDX + [2005, 2010]))
+    add_meta(exp)
 
     obs = process(
         test_df,
@@ -251,7 +260,7 @@ def test_region_processing_skip_aggregation(model_name, region_names):
     # * model "m_a" renames native regions and the world region is skipped
     # * model "m_b" renames single constituent common regions
 
-    input_df = IamDataFrame(
+    test_df = IamDataFrame(
         pd.DataFrame(
             [
                 [model_name, "s_a", region_names[0], "Primary Energy", "EJ/yr", 1, 2],
@@ -260,6 +269,8 @@ def test_region_processing_skip_aggregation(model_name, region_names):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(test_df)
+
     exp = IamDataFrame(
         pd.DataFrame(
             [
@@ -269,9 +280,10 @@ def test_region_processing_skip_aggregation(model_name, region_names):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
+    add_meta(exp)
 
     obs = process(
-        input_df,
+        test_df,
         dsd := DataStructureDefinition(
             TEST_DATA_DIR / "region_processing/skip_aggregation/dsd"
         ),
@@ -381,14 +393,19 @@ def test_partial_aggregation(input_data, exp_data, warning, caplog):
     # * Using the region-aggregation attribute to create an additional variable
     # * Variable is available in provided and aggregated data but different
 
+    test_df = IamDataFrame(pd.DataFrame(input_data, columns=IAMC_IDX + [2005, 2010]))
+    add_meta(test_df)
+
     obs = process(
-        IamDataFrame(pd.DataFrame(input_data, columns=IAMC_IDX + [2005, 2010])),
+        test_df,
         dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),
         processor=RegionProcessor.from_directory(
             TEST_DATA_DIR / "region_processing/partial_aggregation", dsd
         ),
     )
+
     exp = IamDataFrame(pd.DataFrame(exp_data, columns=IAMC_IDX + [2005, 2010]))
+    add_meta(exp)
 
     # Assert that we get the expected values
     assert_iamframe_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,7 +63,7 @@ def test_region_processing_empty_raises(rp_dir):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
-    with pytest.raises(ValueError, match=("'model_a', 'model_b'.*empty dataset")):
+    with pytest.raises(ValueError, match=("Region.*'model_a'.*empty dataset")):
         process(
             test_df,
             dsd := DataStructureDefinition(TEST_DATA_DIR / "region_processing/dsd"),


### PR DESCRIPTION
This PR fixes a bug where meta-indicators are dropped in a specific combination of arguments. The culprit is fixed specifically in https://github.com/IAMconsortium/nomenclature/pull/228/commits/71d7ec747fc4ad7ebfa7102083be7d1e71ba136c (and no, it wasn't a pyam bug).

The subsequent commit refactors the apply-code to only operate on the timeseries data and add meta-indicators at the end of the loop.

closes #227 