### PR TITLE
Updated nomenclature documentation by removing the methods from being listed in the sidebar

### DIFF
--- a/doc/source/_templates/navigation.html
+++ b/doc/source/_templates/navigation.html
@@ -3,7 +3,7 @@
      see https://github.com/bitprophet/alabaster/issues/89 -->
 
 <h3>{{ _('Navigation') }}</h3>
-{{ toctree(maxdepth=4, includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse) }}
+{{ toctree(maxdepth=2, includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse) }}
 {% if theme_extra_nav_links %}
 <hr />
 <ul>


### PR DESCRIPTION
By adding :noindex: to these files I was able to remove the methods from being listed in the sidebar of the nomenclature documentation. The one tradeoff is that they are also no longer listed on the api documentation page that has the table of contents for that section.