### PR TITLE
Second PR to update the Nomenclature documentation

### DIFF
--- a/doc/source/api/codelist.rst
+++ b/doc/source/api/codelist.rst
@@ -4,7 +4,7 @@
 ============
 
 .. autoclass:: CodeList
-   :members: validate_items, from_directory, read_excel, to_yaml, to_pandas, to_csv, to_excel, codelist_repr, filter 
+   :members: from_directory, read_excel, validate_items, filter, to_yaml, to_pandas, to_csv, to_excel
 
 
 .. autoclass:: VariableCodeList

--- a/doc/source/api/codelist.rst
+++ b/doc/source/api/codelist.rst
@@ -4,11 +4,11 @@
 ============
 
 .. autoclass:: CodeList
-   :members: from_directory, read_excel, to_yaml, to_pandas, to_csv, to_excel, filter 
+   :members: validate_items, from_directory, read_excel, to_yaml, to_pandas, to_csv, to_excel, codelist_repr, filter 
 
 
 .. autoclass:: VariableCodeList
-   :members: check_variable_region_aggregation_args, check_weight_in_vars, vars_default_args
+   :members: check_variable_region_aggregation_args, check_weight_in_vars, cast_variable_components_args, vars_default_args
 
 
 .. autoclass:: RegionCodeList

--- a/doc/source/api/codelist.rst
+++ b/doc/source/api/codelist.rst
@@ -4,12 +4,12 @@
 ============
 
 .. autoclass:: CodeList
-   :members:
+   :members: from_directory, read_excel, to_yaml, to_pandas, to_csv, to_excel, filter 
 
 
 .. autoclass:: VariableCodeList
-   :members:
+   :members: check_variable_region_aggregation_args, check_weight_in_vars, vars_default_args
 
 
 .. autoclass:: RegionCodeList
-   :members:
+   :members: from_directory, hierarchy, filter

--- a/doc/source/api/regionprocessor.rst
+++ b/doc/source/api/regionprocessor.rst
@@ -4,4 +4,4 @@
 ===================
 
 .. autoclass:: RegionProcessor
-   :members:
+   :members: from_directory, validate_with_definition, apply


### PR DESCRIPTION
Hello! I took out what I thought were unnecessary methods listed in the documentation under API Documentation: CodeList and RegionProcessor (but let me know if I need to add back in some), and by doing this I was able to get rid of the table that had been there in previous versions. 