### PR TITLE
Update required data validator

### DIFF
--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 import pyam
 from pydantic import validate_arguments
@@ -15,7 +15,7 @@ def process(
     df: pyam.IamDataFrame,
     dsd: DataStructureDefinition,
     dimensions: Optional[list[str]] = None,
-    processor: Optional[Union[Processor, list[Processor]]] = None,
+    processor: Optional[Union[Processor, List[Processor]]] = None,
 ) -> pyam.IamDataFrame:
     """Function for validation and region aggregation in one step
 

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def process(
     df: pyam.IamDataFrame,
     dsd: DataStructureDefinition,
-    dimensions: Optional[list[str]] = None,
+    dimensions: Optional[List[str]] = None,
     processor: Optional[Union[Processor, List[Processor]]] = None,
 ) -> pyam.IamDataFrame:
     """Function for validation and region aggregation in one step

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -1,12 +1,11 @@
-import copy
 import logging
-from typing import List, Optional
+from typing import Optional, Union
 
 import pyam
 from pydantic import validate_arguments
 
 from nomenclature.definition import DataStructureDefinition
-from nomenclature.processor import RegionProcessor
+from nomenclature.processor import Processor, RegionProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -15,8 +14,8 @@ logger = logging.getLogger(__name__)
 def process(
     df: pyam.IamDataFrame,
     dsd: DataStructureDefinition,
-    dimensions: Optional[List[str]] = None,
-    processor: Optional[RegionProcessor] = None,
+    dimensions: Optional[list[str]] = None,
+    processor: Optional[Union[Processor, list[Processor]]] = None,
 ) -> pyam.IamDataFrame:
     """Function for validation and region aggregation in one step
 
@@ -52,21 +51,22 @@ def process(
     ValueError
         If the :class:`pyam.IamDataFrame` fails the validation.
     """
-    # The deep copy is needed so we don't alter dsd in dimensions.remove("region")
-    dimensions = copy.deepcopy(dimensions or dsd.dimensions)
 
-    # perform validation and region-processing (optional)
-    if processor is None:
-        dsd.validate(df, dimensions=dimensions)
-    else:
-        if "region" in dimensions:
-            dimensions.remove("region")
-            dsd.validate(df, dimensions=dimensions)
-            df = processor.apply(df)
-            dsd.validate(df, dimensions=["region"])
-        else:
-            dsd.validate(df, dimensions=dimensions)
-            df = processor.apply(df)
+    processor = processor or []
+    processor = processor if isinstance(processor, list) else [processor]
+
+    dimensions = dimensions or dsd.dimensions
+
+    if (
+        any(isinstance(p, RegionProcessor) for p in processor)
+        and "region" in dimensions
+    ):
+        dimensions.remove("region")
+
+    dsd.validate(df, dimensions=dimensions)
+
+    for p in processor:
+        df = p.apply(df)
 
     # check consistency across the variable hierarchy
     error = dsd.check_aggregate(df)

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -25,7 +25,7 @@ SPECIAL_CODELIST = {
 class DataStructureDefinition:
     """Definition of datastructure codelists for dimensions used in the IAMC format"""
 
-    def __init__(self, path, dimensions=["region", "variable"]):
+    def __init__(self, path, dimensions=None):
         """
 
         Parameters
@@ -36,6 +36,10 @@ class DataStructureDefinition:
             List of :meth:`CodeList` names. Each CodeList is initialized
             from a sub-folder of `path` of that name.
         """
+
+        if dimensions is None:
+            dimensions = ["region", "variable"]
+
         if not isinstance(path, Path):
             path = Path(path)
 

--- a/nomenclature/processor/__init__.py
+++ b/nomenclature/processor/__init__.py
@@ -1,15 +1,4 @@
-import abc
-
-from pyam import IamDataFrame
-from pydantic import BaseModel
-
-
-class Processor(BaseModel, abc.ABC):
-    @abc.abstractmethod
-    def apply(self, df: IamDataFrame) -> IamDataFrame:
-        return
-
-
+from nomenclature.processor.processor import Processor  # noqa
 from nomenclature.processor.region import (  # noqa
     RegionAggregationMapping,
     RegionProcessor,

--- a/nomenclature/processor/__init__.py
+++ b/nomenclature/processor/__init__.py
@@ -1,3 +1,15 @@
+import abc
+
+from pyam import IamDataFrame
+from pydantic import BaseModel
+
+
+class Processor(BaseModel, abc.ABC):
+    @abc.abstractmethod
+    def apply(self, df: IamDataFrame) -> IamDataFrame:
+        return
+
+
 from nomenclature.processor.region import (  # noqa
     RegionAggregationMapping,
     RegionProcessor,

--- a/nomenclature/processor/processor.py
+++ b/nomenclature/processor/processor.py
@@ -1,0 +1,10 @@
+import abc
+
+from pyam import IamDataFrame
+from pydantic import BaseModel
+
+
+class Processor(BaseModel, abc.ABC):
+    @abc.abstractmethod
+    def apply(self, df: IamDataFrame) -> IamDataFrame:
+        return

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -23,6 +23,7 @@ from nomenclature.error.region import (
     RegionNameCollisionError,
     RegionNotDefinedError,
 )
+from nomenclature.processor import Processor
 from nomenclature.processor.utils import get_relative_path
 
 logger = logging.getLogger(__name__)
@@ -313,7 +314,7 @@ class RegionAggregationMapping(BaseModel):
             )
 
 
-class RegionProcessor(BaseModel):
+class RegionProcessor(Processor):
     """Region aggregation mappings for scenario processing"""
 
     region_codelist: RegionCodeList
@@ -423,8 +424,9 @@ class RegionProcessor(BaseModel):
                     f"Applying region-processing for model '{model}' from '{file}'"
                 )
                 processed_dfs.append(self._apply_region_processing(model_df))
-
-        return pyam.concat(processed_dfs)
+        res = pyam.concat(processed_dfs)
+        self.region_codelist.validate_items(res.region)
+        return res
 
     def _apply_region_processing(self, model_df: IamDataFrame) -> IamDataFrame:
         """Apply the region processing for a single model"""

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -409,7 +409,6 @@ class RegionProcessor(Processor):
         """
         processed_dfs: List[IamDataFrame] = []
         for model in df.model:
-
             model_df = df.filter(model=model)
 
             # if no mapping is defined the data frame is returned unchanged
@@ -458,7 +457,6 @@ class RegionProcessor(Processor):
 
             # aggregate common regions
             if self.mappings[model].common_regions is not None:
-
                 for cr in self.mappings[model].common_regions:
                     # if a common region is consists of a single native region, rename
                     if cr.is_single_constituent_region:

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, List
 
 import pydantic
 import yaml
@@ -19,12 +19,12 @@ logger = logging.getLogger(__name__)
 class RequiredMeasurand(BaseModel):
 
     variable: str
-    unit: Optional[Union[str, list[str]]] = Field(...)
+    unit: Optional[Union[str,List[str]]] = Field(...)
 
 
 class RequiredData(BaseModel):
 
-    measurand: list[RequiredMeasurand]
+    measurand:List[RequiredMeasurand]
     region: Optional[list[str]]
     year: Optional[list[int]]
 
@@ -65,11 +65,11 @@ class RequiredData(BaseModel):
             raise ValueError(error_msg)
 
     @property
-    def variable(self) -> list[str]:
+    def variable(self) ->List[str]:
         return [m.variable for m in self.measurand]
 
     @property
-    def pyam_required_data_list(self) -> list[dict]:
+    def pyam_required_data_list(self) ->List[dict]:
 
         return [
             {
@@ -83,8 +83,8 @@ class RequiredData(BaseModel):
 
     def _wrong_unit_variables(
         self, dsd: DataStructureDefinition
-    ) -> list[tuple[str, str, str]]:
-        wrong_units: list[tuple[str, Any, Any]] = []
+    ) ->List[tuple[str, str, str]]:
+        wrong_units:List[tuple[str, Any, Any]] = []
         if hasattr(dsd, "variable"):
             wrong_units.extend(
                 (m.variable, m.unit, dsd.variable[m.variable].unit)
@@ -99,7 +99,7 @@ class RequiredData(BaseModel):
 class RequiredDataValidator(Processor):
 
     name: str
-    required_data: list[RequiredData]
+    required_data:List[RequiredData]
     file: Path
 
     @classmethod

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -1,11 +1,11 @@
 import logging
 from pathlib import Path
-from typing import Any, Optional, Union, List
+from typing import Any, List, Optional, Tuple, Union
 
 import pydantic
 import yaml
 from pyam import IamDataFrame
-from pydantic import BaseModel, validator, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.error_wrappers import ErrorWrapper
 
 from nomenclature.definition import DataStructureDefinition
@@ -83,8 +83,8 @@ class RequiredData(BaseModel):
 
     def _wrong_unit_variables(
         self, dsd: DataStructureDefinition
-    ) -> List[tuple[str, str, str]]:
-        wrong_units: List[tuple[str, Any, Any]] = []
+    ) -> List[Tuple[str, str, str]]:
+        wrong_units: List[Tuple[str, Any, Any]] = []
         if hasattr(dsd, "variable"):
             wrong_units.extend(
                 (m.variable, m.unit, dsd.variable[m.variable].unit)

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -19,14 +19,14 @@ logger = logging.getLogger(__name__)
 class RequiredMeasurand(BaseModel):
 
     variable: str
-    unit: Optional[Union[str,List[str]]] = Field(...)
+    unit: Optional[Union[str, List[str]]] = Field(...)
 
 
 class RequiredData(BaseModel):
 
-    measurand:List[RequiredMeasurand]
-    region: Optional[list[str]]
-    year: Optional[list[int]]
+    measurand: List[RequiredMeasurand]
+    region: Optional[List[str]]
+    year: Optional[List[int]]
 
     @validator("measurand", "region", "year", pre=True)
     def single_input_to_list(cls, v):
@@ -65,11 +65,11 @@ class RequiredData(BaseModel):
             raise ValueError(error_msg)
 
     @property
-    def variable(self) ->List[str]:
+    def variable(self) -> List[str]:
         return [m.variable for m in self.measurand]
 
     @property
-    def pyam_required_data_list(self) ->List[dict]:
+    def pyam_required_data_list(self) -> List[dict]:
 
         return [
             {
@@ -83,8 +83,8 @@ class RequiredData(BaseModel):
 
     def _wrong_unit_variables(
         self, dsd: DataStructureDefinition
-    ) ->List[tuple[str, str, str]]:
-        wrong_units:List[tuple[str, Any, Any]] = []
+    ) -> List[tuple[str, str, str]]:
+        wrong_units: List[tuple[str, Any, Any]] = []
         if hasattr(dsd, "variable"):
             wrong_units.extend(
                 (m.variable, m.unit, dsd.variable[m.variable].unit)
@@ -99,7 +99,7 @@ class RequiredData(BaseModel):
 class RequiredDataValidator(Processor):
 
     name: str
-    required_data:List[RequiredData]
+    required_data: List[RequiredData]
     file: Path
 
     @classmethod

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -6,7 +6,7 @@ import pydantic
 import yaml
 import pyam
 from pyam import IamDataFrame
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, validator
 from pydantic.error_wrappers import ErrorWrapper
 
 from nomenclature.definition import DataStructureDefinition

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -24,13 +24,18 @@ def validate(dsd, df, dimensions):
 
     error = False
 
+    for dim in dimensions:
+        if invalid := dsd.__getattribute__(dim).validate_items(
+            df.__getattribute__(dim)
+        ):
+            log_error(dim, invalid)
+            error = True
+
     if "variable" in dimensions:
-        # combined validation of variables and units
-        invalid_vars, invalid_units = [], []
+        # validation of variable, unit combinations
+        invalid_units = []
         for variable, unit in df.unit_mapping.items():
-            if variable not in dsd.variable:
-                invalid_vars.append(variable)
-            else:
+            if variable in dsd.variable:
                 dsd_unit = dsd.variable[variable].unit
                 # fast-pass for unique units in df and the DataStructureDefinition
                 if dsd_unit == unit:
@@ -40,10 +45,6 @@ def validate(dsd, df, dimensions):
                     continue
                 invalid_units.append((variable, unit, dsd_unit))
 
-        if invalid_vars:
-            log_error("variable", invalid_vars)
-            error = True
-
         if invalid_units:
             lst = [
                 f"'{v}' - expected: {'one of ' if isinstance(e, list) else ''}"
@@ -52,13 +53,6 @@ def validate(dsd, df, dimensions):
             ]
             msg = "The following variable(s) are reported with the wrong unit:"
             logger.error("\n - ".join([msg] + lst))
-            error = True
-
-    # validation of all other dimensions
-    for dim in [d for d in dimensions if d != "variable"]:
-        invalid = dsd.__getattribute__(dim).validate_items(df.__getattribute__(dim))
-        if invalid:
-            log_error(dim, invalid)
             error = True
 
     if error:

--- a/tests/data/required_data/required_data/requiredData.yaml
+++ b/tests/data/required_data/required_data/requiredData.yaml
@@ -1,4 +1,4 @@
-name: MAGICC
+model: model_a
 required_data:
   - measurand:
       Emissions|CO2:

--- a/tests/data/required_data/required_data/requiredData.yaml
+++ b/tests/data/required_data/required_data/requiredData.yaml
@@ -1,3 +1,4 @@
+description: Required variables for running MAGICC
 model: model_a
 required_data:
   - measurand:

--- a/tests/data/required_data/required_data/requiredData.yaml
+++ b/tests/data/required_data/required_data/requiredData.yaml
@@ -1,10 +1,8 @@
 name: MAGICC
 required_data:
-  - variable: Emissions|CO2
+  - measurand:
+      Emissions|CO2:
+        unit: Mt CO2/yr
     region: World
     year: [2020, 2030, 2040, 2050]
-optional_data:
-  - variable: Emissions|CH4
-    region: World
-    year: [2020, 2025, 2050, 2075, 2100]
 

--- a/tests/data/required_data/required_data/requiredData_any_unit.yaml
+++ b/tests/data/required_data/required_data/requiredData_any_unit.yaml
@@ -1,0 +1,7 @@
+model: model_a
+required_data:
+  - measurand:
+      Primary Energy:
+    region: World
+    year: [2005, 2010]
+

--- a/tests/data/required_data/required_data/requiredData_any_unit.yaml
+++ b/tests/data/required_data/required_data/requiredData_any_unit.yaml
@@ -1,7 +1,6 @@
-model: model_a
 required_data:
-  - measurand:
-      Primary Energy:
+  - variable:
+    - Primary Energy
     region: World
     year: [2005, 2010]
 

--- a/tests/data/required_data/required_data/requiredData_apply_error.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_error.yaml
@@ -1,5 +1,7 @@
 name: Raises error with simple_df fixture from conftest
 required_data:
-  - variable: Primary Energy
+  - measurand:
+    - Primary Energy:
+        unit: EJ/yr
     year: [2005, 2010, 2015] # 2015 is missing from simple_df for all models
-    unit: EJ/yr
+

--- a/tests/data/required_data/required_data/requiredData_apply_error.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_error.yaml
@@ -1,4 +1,4 @@
-name: Raises error with simple_df fixture from conftest
+model: model_a
 required_data:
   - measurand:
     - Primary Energy:

--- a/tests/data/required_data/required_data/requiredData_apply_error.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_error.yaml
@@ -2,6 +2,6 @@ model: model_a
 required_data:
   - measurand:
     - Primary Energy:
-        unit: EJ/yr
+        unit: [GWh/yr, Mtoe]
     year: [2005, 2010, 2015] # 2015 is missing from simple_df for all models
 

--- a/tests/data/required_data/required_data/requiredData_apply_working.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_working.yaml
@@ -1,5 +1,6 @@
 name: Runs through with simple_df fixture from conftest
 required_data:
-  - variable: Primary Energy
+  - measurand:
+      - Primary Energy:
+          unit: EJ/yr
     year: [2005, 2010]
-    unit: EJ/yr

--- a/tests/data/required_data/required_data/requiredData_apply_working.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_working.yaml
@@ -1,4 +1,4 @@
-name: Runs through with simple_df fixture from conftest
+model: model_a
 required_data:
   - measurand:
       - Primary Energy:

--- a/tests/data/required_data/required_data/requiredData_multiple_units_allowed.yaml
+++ b/tests/data/required_data/required_data/requiredData_multiple_units_allowed.yaml
@@ -1,0 +1,9 @@
+model: model_a
+required_data:
+  - measurand:
+      Primary Energy:
+        unit: [EJ/yr, PWh/yr, Mtoe/yr]
+        unit: [EJ/yr, PWh/yr, Mtoe/yr]
+    region: World
+    year: [2005, 2010]
+

--- a/tests/data/required_data/required_data/requiredData_multiple_units_allowed.yaml
+++ b/tests/data/required_data/required_data/requiredData_multiple_units_allowed.yaml
@@ -3,7 +3,6 @@ required_data:
   - measurand:
       Primary Energy:
         unit: [EJ/yr, PWh/yr, Mtoe/yr]
-        unit: [EJ/yr, PWh/yr, Mtoe/yr]
     region: World
     year: [2005, 2010]
 

--- a/tests/data/required_data/required_data/requiredData_unknown_region.yaml
+++ b/tests/data/required_data/required_data/requiredData_unknown_region.yaml
@@ -1,4 +1,6 @@
 name: Unknown region
 required_data:
-  - variable: Final Energy
+  - measurand:
+      Final Energy:
+        unit: EJ/yr
     region: Asia

--- a/tests/data/required_data/required_data/requiredData_unknown_region.yaml
+++ b/tests/data/required_data/required_data/requiredData_unknown_region.yaml
@@ -1,4 +1,4 @@
-name: Unknown region
+model: model_a
 required_data:
   - measurand:
       Final Energy:

--- a/tests/data/required_data/required_data/requiredData_unknown_unit.yaml
+++ b/tests/data/required_data/required_data/requiredData_unknown_unit.yaml
@@ -1,4 +1,4 @@
-name: Unknown unit
+model: model_a
 required_data:
   - measurand:
       Final Energy:

--- a/tests/data/required_data/required_data/requiredData_unknown_unit.yaml
+++ b/tests/data/required_data/required_data/requiredData_unknown_unit.yaml
@@ -1,4 +1,5 @@
 name: Unknown unit
 required_data:
-  - variable: Final Energy
-    unit: Mtoe/yr
+  - measurand:
+      Final Energy:
+        unit: Mtoe/yr

--- a/tests/data/required_data/required_data/requiredData_unknown_variable.yaml
+++ b/tests/data/required_data/required_data/requiredData_unknown_variable.yaml
@@ -1,3 +1,5 @@
 name: Unknown variable
 required_data:
-  - variable: Final Energy|Industry
+  - measurand:
+      Final Energy|Industry:
+        unit: EJ/yr

--- a/tests/data/required_data/required_data/requiredData_unknown_variable.yaml
+++ b/tests/data/required_data/required_data/requiredData_unknown_variable.yaml
@@ -1,4 +1,4 @@
-name: Unknown variable
+model: model_a
 required_data:
   - measurand:
       Final Energy|Industry:

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -74,10 +74,18 @@ def test_RequiredDataValidator_validate_with_definition_raises(requiredDataFile,
         required_data_validator.validate_with_definition(dsd)
 
 
-def test_RequiredData_apply(simple_df):
+@pytest.mark.parametrize(
+    "required_data_file",
+    [
+        "requiredData_apply_working.yaml",
+        "requiredData_any_unit.yaml",
+        "requiredData_multiple_units_allowed.yaml",
+    ],
+)
+def test_RequiredData_apply(simple_df, required_data_file):
     # all good no warnings
     required_data_validator = RequiredDataValidator.from_file(
-        REQUIRED_DATA_TEST_DIR / "requiredData_apply_working.yaml"
+        REQUIRED_DATA_TEST_DIR / required_data_file
     )
     assert_iamframe_equal(required_data_validator.apply(simple_df), simple_df)
 

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -4,6 +4,7 @@ from conftest import TEST_DATA_DIR
 
 from pyam import assert_iamframe_equal
 from nomenclature import DataStructureDefinition, RequiredDataValidator
+from nomenclature.processor.required_data import RequiredMeasurand
 from nomenclature.error.required_data import RequiredDataMissingError
 
 REQUIRED_DATA_TEST_DIR = TEST_DATA_DIR / "required_data" / "required_data"
@@ -15,10 +16,11 @@ def test_RequiredDataValidator_from_file():
         "name": "MAGICC",
         "required_data": [
             {
-                "variable": ["Emissions|CO2"],
+                "measurand": [
+                    RequiredMeasurand(variable="Emissions|CO2", unit="Mt CO2/yr")
+                ],
                 "region": ["World"],
                 "year": [2020, 2030, 2040, 2050],
-                "unit": None,
             },
         ],
         "file": REQUIRED_DATA_TEST_DIR / "requiredData.yaml",

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -13,6 +13,7 @@ REQUIRED_DATA_TEST_DIR = TEST_DATA_DIR / "required_data" / "required_data"
 
 def test_RequiredDataValidator_from_file():
     exp = {
+        "description": "Required variables for running MAGICC",
         "model": ["model_a"],
         "required_data": [
             {
@@ -28,7 +29,7 @@ def test_RequiredDataValidator_from_file():
 
     obs = RequiredDataValidator.from_file(REQUIRED_DATA_TEST_DIR / "requiredData.yaml")
 
-    assert obs.dict() == exp
+    assert obs.dict(exclude_unset=True) == exp
 
 
 def test_RequiredDataValidator_validate_with_definition():


### PR DESCRIPTION
closes #215.
This PR enables the use of `RequiredDataValidator` as part of `process()`.

## Changes implemented

* `process()` now takes a `processor` argument which can be a list of `Processor` objects. It can also still just be a single `Processor` so the change is not breaking.
* In order to make the above work I introduced an abstract base class called `Processor` from which `RegionProcessor` and `RequiredDataValidator` inherit.
* Slightly updated the way variable, unit combinations are given in the yaml file of a `RequiredDataValidator`. Since we've coined the term measurand for a variable, unit combination I went with that.
* Moved the region validation inside `RegionProcessor`.

FYI @GretchenSchowalter.