### PR TITLE
Streamline code list filter

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -406,11 +406,11 @@ class CodeList(BaseModel):
         # Returns True if code satisfies all filter parameters
         def _match_attribute(code, kwargs):
             return all(
-                hasattr(code, attribute) and getattr(code, attribute, None) == value
+                hasattr(code, attribute) and getattr(code, attribute) == value
                 for attribute, value in kwargs.items()
             )
 
-        filtered_codelist = CodeList(
+        filtered_codelist = self.__class__(
             name=self.name,
             mapping={
                 code.name: code
@@ -420,7 +420,7 @@ class CodeList(BaseModel):
         )
 
         if not filtered_codelist.mapping:
-            logging.warning("Formatted data is empty!")
+            logging.warning(f"Filtered {self.__class__.__name__} is empty!")
         return filtered_codelist
 
 

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -590,41 +590,6 @@ class RegionCodeList(CodeList):
         """
         return sorted(list(set(v.hierarchy for v in self.mapping.values())))
 
-    def filter(self, hierarchy: str) -> "RegionCodeList":
-        """Return a filtered RegionCodeList object
-
-        Parameters
-        ----------
-        hierarchy : str
-            String with filter parameter.
-
-        Raises
-        ------
-        ValueError
-            Provided hierarchy is not compatible with the given model.
-
-        Returns
-        -------
-        :class:'RegionCodeList'
-
-        Notes
-        -----
-        The following arguments are available for filtering:
-
-        - 'hierarchy': filter by the hierarchy of each region
-
-        """
-
-        mapping = {k: v for k, v in self.mapping.items() if v.hierarchy == hierarchy}
-        if mapping:
-            return RegionCodeList(name=self.name, mapping=mapping)
-        else:
-            msg: str = (
-                f"Filtered RegionCodeList is empty: hierarchy={hierarchy}\n"
-                "Use `RegionCodeList.hierarchy` method for available items."
-            )
-            raise ValueError(msg)
-
 
 class MetaCodeList(CodeList):
     """A subclass of CodeList specified for MetaCodes

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -240,22 +240,6 @@ def test_RegionCodeList_filter():
     assert obs == exp
 
 
-def test_RegionCodeList_filter_ValueError():
-    """Test that verifies the filter gives error when user inputs an unrecognizeable
-    hierarchy"""
-
-    # read RegionCodeList
-    rcl = RegionCodeList.from_directory(
-        "Region", TEST_DATA_DIR / "region_to_filter_codelist"
-    )
-    match = (
-        "Filtered RegionCodeList is empty: hierarchy=R77\n"
-        "Use `RegionCodeList.hierarchy` method for available items."
-    )
-    with pytest.raises(ValueError, match=match):
-        rcl.filter(hierarchy="R77")
-
-
 def test_RegionCodeList_hierarchy():
     """Verifies that the hierarchy method returns a List[str]"""
 

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -218,7 +218,7 @@ def test_RegionCodeList_filter():
     rcl = RegionCodeList.from_directory(
         "Region", TEST_DATA_DIR / "region_to_filter_codelist"
     )
-    obs = rcl.filter("countries")
+    obs = rcl.filter(hierarchy="countries")
     extra_attributes = {
         "file": "region_to_filter_codelist/region_filtering.yaml",
     }
@@ -253,7 +253,7 @@ def test_RegionCodeList_filter_ValueError():
         "Use `RegionCodeList.hierarchy` method for available items."
     )
     with pytest.raises(ValueError, match=match):
-        rcl.filter("R77")
+        rcl.filter(hierarchy="R77")
 
 
 def test_RegionCodeList_hierarchy():
@@ -310,7 +310,7 @@ def test_codelist_general_filter_No_Elements(caplog):
         assert obs == CodeList(name="Variable", mapping={})
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
-        assert caplog.records[0].message == "Formatted data is empty!"
+        assert caplog.records[0].message == "Filtered CodeList is empty!"
 
 
 def test_MetaCodeList_from_directory():


### PR DESCRIPTION
As discussed at the end of #236 this PR removes `RegionCodeList.filter()` in favor of using the more generic `CodeList.filter()`.
The one slight difference, and reason why there's currently one test failing is that the logic of what happens if the filter function returns nothing is/was different between `RegionCodeList.filter()` and `CodeList.filter()`:

* If `CodeList.filter()` returns nothing, a warning is issued.
* If `RegionCodeList.filter()` returns nothing, an error is raised.

With removing the latter, there's now only ever a warning, which to me is fine. 

Looking forward to your input @GretchenSchowalter and @danielhuppmann.

-----

EDIT: I removed the the unit test for `RegionCodeList.filter()` that tests for the empty codelist. Reason being is that there's no longer any difference between `RegionCodeList.filter()` and `CodeList.filter()` and we already have a unit test for an empty return.