### PR TITLE
Renamed 'countries' attribute to 'iso3_codes'in RegionCode class

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -220,15 +220,15 @@ class RegionCode(Code):
     """
 
     hierarchy: str = None
-    countries: List[str] = None
+    iso3_codes: List[str] = None
 
-    @validator("countries")
+    @validator("iso3_codes")
     def check_iso3_codes(cls, v, values) -> List[str]:
         """Verifies that each ISO3 code is valid according to pycountry library."""
         invalid_iso3_codes: List[str] = []
-        for country in v:
-            if pycountry.countries.get(alpha_3=country) is None:
-                invalid_iso3_codes.append(country)
+        for iso3_code in v:
+            if pycountry.countries.get(alpha_3=iso3_code) is None:
+                invalid_iso3_codes.append(iso3_code)
         if invalid_iso3_codes:
             raise ValueError(
                 f"Region {values['name']} has invalid"

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -61,7 +61,7 @@ def test_RegionCode_iso3_code():
     reg = RegionCode(
         name="Western Europe",
         hierarchy="R5OECD",
-        countries=[
+        iso3_codes=[
             "DNK",
             "IRL",
             "AUT",
@@ -90,7 +90,7 @@ def test_RegionCode_iso3_code():
         ],
     )
 
-    assert reg.countries == [
+    assert reg.iso3_codes == [
         "DNK",
         "IRL",
         "AUT",
@@ -120,7 +120,7 @@ def test_RegionCode_iso3_code():
 
 
 def test_RegionCode_iso3_code_fail():
-    countries = [
+    iso3_codes = [
         "DMK",
         "IPL",
         "ATZ",
@@ -149,7 +149,7 @@ def test_RegionCode_iso3_code_fail():
     ]
 
     error_pattern = (
-        "1 validation error for RegionCode\ncountries\n  Reg"
+        "1 validation error for RegionCode\niso3_codes\n  Reg"
         "ion Western Europe has invalid ISO3 country codes"
         ": \['DMK', 'IPL', 'ATZ', 'FNL', 'FRE', 'DEX', 'GRE',"  # noqa
         " 'IBL', 'ITL', 'LIC', 'MLA', 'BEG', 'FRT', 'ANB', "  # noqa
@@ -157,7 +157,7 @@ def test_RegionCode_iso3_code_fail():
         "'SWD', 'CEW', 'GTR', 'SOR'\] \(type=value_error\)"  # noqa
     )
     with pytest.raises(ValueError, match=error_pattern):
-        RegionCode(name="Western Europe", hierarchy="R5OECD", countries=countries)
+        RegionCode(name="Western Europe", hierarchy="R5OECD", iso3_codes=iso3_codes)
 
 
 def test_MetaCode_allowed_values_attribute():


### PR DESCRIPTION
Hey, Daniel! This is a quick PR to address issue #251. I changed the attribute name from _countries_ to _iso3_codes_. Let me know if anything else needs to be changed!

closes #251