### PR TITLE
Allow ISO3 codes as string

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -1,5 +1,6 @@
 import json
 import re
+import pyam
 import pycountry
 from keyword import iskeyword
 from pathlib import Path
@@ -220,13 +221,13 @@ class RegionCode(Code):
     """
 
     hierarchy: str = None
-    iso3_codes: List[str] = None
+    iso3_codes: Union[List[str], str] = None
 
     @validator("iso3_codes")
     def check_iso3_codes(cls, v, values) -> List[str]:
         """Verifies that each ISO3 code is valid according to pycountry library."""
         invalid_iso3_codes: List[str] = []
-        for iso3_code in v:
+        for iso3_code in pyam.to_list(v):
             if pycountry.countries.get(alpha_3=iso3_code) is None:
                 invalid_iso3_codes.append(iso3_code)
         if invalid_iso3_codes:

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -226,14 +226,14 @@ class RegionCode(Code):
     @validator("iso3_codes")
     def check_iso3_codes(cls, v, values) -> List[str]:
         """Verifies that each ISO3 code is valid according to pycountry library."""
-        invalid_iso3_codes: List[str] = []
-        for iso3_code in pyam.to_list(v):
-            if pycountry.countries.get(alpha_3=iso3_code) is None:
-                invalid_iso3_codes.append(iso3_code)
-        if invalid_iso3_codes:
-            invalid = ", ".join(invalid_iso3_codes)
+        if invalid_iso3_codes := [
+            iso3_code
+            for iso3_code in pyam.to_list(v)
+            if pycountry.countries.get(alpha_3=iso3_code) is None
+        ]:
             raise ValueError(
-                f"Region {values['name']} has invalid ISO3 country codes: {invalid}"
+                f"Region '{values['name']}' has invalid ISO3 country code(s): "
+                + ", ".join(invalid_iso3_codes)
             )
         return v
 

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -231,9 +231,9 @@ class RegionCode(Code):
             if pycountry.countries.get(alpha_3=iso3_code) is None:
                 invalid_iso3_codes.append(iso3_code)
         if invalid_iso3_codes:
+            invalid = ", ".join(invalid_iso3_codes)
             raise ValueError(
-                f"Region {values['name']} has invalid"
-                f" ISO3 country codes: {invalid_iso3_codes}"
+                f"Region {values['name']} has invalid ISO3 country codes: {invalid}"
             )
         return v
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -154,10 +154,10 @@ def test_RegionCode_iso3_code_list_fail():
     ]
 
     error_pattern = (
-        "1 validation error for RegionCode\niso3_codes\n  Region Western Europe has "
-        "invalid ISO3 country codes: DMK, IPL, ATZ, FNL, FRE, DEX, GRE, IBL, "  # noqa
-        "ITL, LIC, MLA, BEG, FRT, ANB, GDR, LXB, MNO, NTD, NRW, PRE, EPA, SWD, "  # noqa
-        "CEW, GTR, SOR \(type=value_error\)"  # noqa
+        "1 validation error for RegionCode\niso3_codes\n  Region 'Western Europe' has "
+        "invalid ISO3 country code\(s\): DMK, IPL, ATZ, FNL, FRE, DEX, GRE, "  # noqa
+        "IBL, ITL, LIC, MLA, BEG, FRT, ANB, GDR, LXB, MNO, NTD, NRW, PRE, EPA, "  # noqa
+        "SWD, CEW, GTR, SOR \(type=value_error\)"  # noqa
     )
     with pytest.raises(ValueError, match=error_pattern):
         RegionCode(name="Western Europe", hierarchy="R5OECD", iso3_codes=iso3_codes)
@@ -165,8 +165,8 @@ def test_RegionCode_iso3_code_list_fail():
 
 def test_RegionCode_iso3_code_str_fail():
     error_pattern = (
-        "1 validation error for RegionCode\niso3_codes\n  Region Austria has invalid "
-        "ISO3 country codes: AUTT \(type=value_error\)"
+        "1 validation error for RegionCode\niso3_codes\n  Region 'Austria' has invalid "
+        "ISO3 country code\(s\): AUTT \(type=value_error\)"
     )
     with pytest.raises(ValueError, match=error_pattern):
         RegionCode(name="Austria", hierarchy="country", iso3_codes="AUTT")

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -154,12 +154,10 @@ def test_RegionCode_iso3_code_list_fail():
     ]
 
     error_pattern = (
-        "1 validation error for RegionCode\niso3_codes\n  Reg"
-        "ion Western Europe has invalid ISO3 country codes"
-        ": \['DMK', 'IPL', 'ATZ', 'FNL', 'FRE', 'DEX', 'GRE',"  # noqa
-        " 'IBL', 'ITL', 'LIC', 'MLA', 'BEG', 'FRT', 'ANB', "  # noqa
-        "'GDR', 'LXB', 'MNO', 'NTD', 'NRW', 'PRE', 'EPA', "  # noqa
-        "'SWD', 'CEW', 'GTR', 'SOR'\] \(type=value_error\)"  # noqa
+        "1 validation error for RegionCode\niso3_codes\n  Region Western Europe has "
+        "invalid ISO3 country codes: DMK, IPL, ATZ, FNL, FRE, DEX, GRE, IBL, "  # noqa
+        "ITL, LIC, MLA, BEG, FRT, ANB, GDR, LXB, MNO, NTD, NRW, PRE, EPA, SWD, "  # noqa
+        "CEW, GTR, SOR \(type=value_error\)"  # noqa
     )
     with pytest.raises(ValueError, match=error_pattern):
         RegionCode(name="Western Europe", hierarchy="R5OECD", iso3_codes=iso3_codes)
@@ -167,8 +165,8 @@ def test_RegionCode_iso3_code_list_fail():
 
 def test_RegionCode_iso3_code_str_fail():
     error_pattern = (
-        "1 validation error for RegionCode\niso3_codes\n  Region Austria"
-        " has invalid ISO3 country codes: \['AUTT'\] \(type=value_error\)"
+        "1 validation error for RegionCode\niso3_codes\n  Region Austria has invalid "
+        "ISO3 country codes: AUTT \(type=value_error\)"
     )
     with pytest.raises(ValueError, match=error_pattern):
         RegionCode(name="Austria", hierarchy="country", iso3_codes="AUTT")

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -57,7 +57,7 @@ def test_RegionCode_hierarchy_attribute():
     assert reg.hierarchy == "R5"
 
 
-def test_RegionCode_iso3_code():
+def test_RegionCode_iso3_code_list():
     reg = RegionCode(
         name="Western Europe",
         hierarchy="R5OECD",
@@ -119,7 +119,12 @@ def test_RegionCode_iso3_code():
     ]
 
 
-def test_RegionCode_iso3_code_fail():
+def test_RegionCode_iso3_code_str():
+    reg = RegionCode(name="Austria", hierarchy="country", iso3_codes="AUT")
+    assert reg.iso3_codes == "AUT"
+
+
+def test_RegionCode_iso3_code_list_fail():
     iso3_codes = [
         "DMK",
         "IPL",
@@ -158,6 +163,15 @@ def test_RegionCode_iso3_code_fail():
     )
     with pytest.raises(ValueError, match=error_pattern):
         RegionCode(name="Western Europe", hierarchy="R5OECD", iso3_codes=iso3_codes)
+
+
+def test_RegionCode_iso3_code_str_fail():
+    error_pattern = (
+        "1 validation error for RegionCode\niso3_codes\n  Region Austria"
+        " has invalid ISO3 country codes: \['AUTT'\] \(type=value_error\)"
+    )
+    with pytest.raises(ValueError, match=error_pattern):
+        RegionCode(name="Austria", hierarchy="country", iso3_codes="AUTT")
 
 
 def test_MetaCode_allowed_values_attribute():


### PR DESCRIPTION
Trying to implement ISO3 codes for the ECEMF/openENTRANCE project, I realized that the list was overly complicated for a list of countries. So this PR extends the "iso3_codes" attribute to be provided as a string. It also makes the error message slightly more readable by un-listing...