### PR TITLE
Add a module for translating between country names and alpha-2/3 codes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,4 +13,5 @@ API documentation
    api/datastructureconfig
    api/codelist
    api/regionprocessor
+   api/countries
    api/testing

--- a/docs/api/countries.rst
+++ b/docs/api/countries.rst
@@ -1,0 +1,30 @@
+.. currentmodule:: nomenclature.countries
+
+A common list of countries
+==========================
+
+Having an agreed list of country names including a mapping to alpha-3 and alpha-2 codes
+(also know as ISO3 and ISO2 codes) is an important prerequisite for scenario analysis
+and model comparison.
+
+The :class:`nomenclature` package builds on the :class:`pycountry` package
+(`link <https://github.com/flyingcircusio/pycountry>`_) to provide a utility for country
+names based on the ISO 3166-1 standard.
+
+For consistency with conventions in the modelling community, several
+country names are shortened compared to ISO 3166-1 ,
+e.g. from "Bolivia, Plurinational State of" to "Bolivia".
+Also, "Kosovo" is added even though it is not a universally recognized state.
+
+You can use this utility for mapping between country names as used in the community
+and alpha-3 or alpha-2 codes, as shown in this example.
+
+.. code:: python
+
+  from nomenclature import countries
+
+  name = countries.get(alpha_3="...").name
+  alpha_3 = countries.get(name="...").alpha_3
+
+.. autoclass:: Countries
+   :members: get

--- a/docs/api/countries.rst
+++ b/docs/api/countries.rst
@@ -13,13 +13,15 @@ The :class:`nomenclature` package builds on the :class:`pycountry` package
 (`link <https://github.com/flyingcircusio/pycountry>`_) to provide a utility for country
 names based on the ISO 3166-1 standard.
 
-For consistency with conventions in the modelling community, several
-country names are shortened compared to ISO 3166-1 ,
-e.g. from "Bolivia, Plurinational State of" to "Bolivia".
+For consistency with conventions in the modelling community, several country names are
+shortened compared to ISO 3166-1 , e.g. from "Bolivia, Plurinational State of" to "Bolivia".
 Also, "Kosovo" is added even though it is not a universally recognized state.
+See the full list of changes on GitHub_.
 
 You can use this utility for mapping between country names as used in the community
 and alpha-3 or alpha-2 codes, as shown in this example.
+
+.. _GitHub: https://github.com/IAMconsortium/nomenclature/blob/main/nomenclature/countries.py
 
 .. code:: python
 
@@ -27,6 +29,7 @@ and alpha-3 or alpha-2 codes, as shown in this example.
 
   name = countries.get(alpha_3="...").name
   alpha_3 = countries.get(name="...").alpha_3
+  alpha_2 = countries.get(name="...").alpha_2
 
 .. autoclass:: Countries
    :members: get

--- a/docs/api/countries.rst
+++ b/docs/api/countries.rst
@@ -1,3 +1,5 @@
+.. _countries:
+
 .. currentmodule:: nomenclature.countries
 
 A common list of countries

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,10 @@ The **nomenclature** package supports three main use cases:
 The codelists and mappings are stored as yaml files.
 Refer to the :ref:`user_guide` for more information.
 
+The **nomenclature** package also provides a utility for translating between country
+names (as commonly used in the modelling community) and alpha-3/alpha-2 codes (also
+known as *ISO3/ISO2 codes*). Read the docs on :ref:`countries` for more information.
+
 Table of Contents
 -----------------
 

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -13,7 +13,7 @@ from nomenclature.processor import (  # noqa
     RegionProcessor,
     RequiredDataValidator,
 )
-from nomenclature.countries import countries
+from nomenclature.countries import countries  # noqa
 
 # set up logging
 logging.basicConfig(

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -13,6 +13,7 @@ from nomenclature.processor import (  # noqa
     RegionProcessor,
     RequiredDataValidator,
 )
+from nomenclature.countries import countries
 
 # set up logging
 logging.basicConfig(

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -554,9 +554,11 @@ class RegionCodeList(CodeList):
             if config.region.country is True:
                 for i in countries:
                     try:
-                        code_list.append(RegionCode(
-                            name=i.name, iso3_codes=i.alpha_3, hierarchy="Country"
-                        ))
+                        code_list.append(
+                            RegionCode(
+                                name=i.name, iso3_codes=i.alpha_3, hierarchy="Country"
+                            )
+                        )
                     # special handling for countries that do not have an alpha_3 code
                     except AttributeError:
                         code_list.append(RegionCode(name=i.name, hierarchy="Country"))

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -552,7 +552,6 @@ class RegionCodeList(CodeList):
 
         # initializing from general configuration
         if config is not None and config.region is not None:
-
             # adding all countries
             if config.region.country is True:
                 for c in countries:

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -552,11 +552,11 @@ class RegionCodeList(CodeList):
 
         if config is not None and config.region is not None:
             if config.region.country is True:
-                for i in countries:
+                for c in countries:
                     try:
                         code_list.append(
                             RegionCode(
-                                name=i.name, iso3_codes=i.alpha_3, hierarchy="Country"
+                                name=c.name, iso3_codes=c.alpha_3, hierarchy="Country"
                             )
                         )
                     # special handling for countries that do not have an alpha_3 code

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -550,7 +550,10 @@ class RegionCodeList(CodeList):
 
         code_list: List[RegionCode] = []
 
+        # initializing from general configuration
         if config is not None and config.region is not None:
+
+            # adding all countries
             if config.region.country is True:
                 for c in countries:
                     try:
@@ -561,7 +564,9 @@ class RegionCodeList(CodeList):
                         )
                     # special handling for countries that do not have an alpha_3 code
                     except AttributeError:
-                        code_list.append(RegionCode(name=i.name, hierarchy="Country"))
+                        code_list.append(RegionCode(name=c.name, hierarchy="Country"))
+
+            # importing from an external repository
             if repo := config.region.repository:
                 repo_path = path.parents[1] / repo
                 if not repo_path.exists():
@@ -573,9 +578,11 @@ class RegionCodeList(CodeList):
                     code_list, repo_path, file_glob_pattern
                 )
 
+        # parse from current repository
         code_list = cls._parse_region_code_dir(code_list, path, file_glob_pattern)
         code_list = cls._parse_and_replace_tags(code_list, path, file_glob_pattern)
 
+        # translate to mapping
         mapping: Dict[str, RegionCode] = {}
         for code in code_list:
             if code.name in mapping:

--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -1,0 +1,65 @@
+import os
+import pycountry
+
+# `nomenclature` uses pycountry to (optionally) add all countries and ISO3 codes
+# For readability and in line with conventions of the IAMC community,
+# several "standard" country names are shortened
+# Please keep this list in sync with `templates/model-registration-template.xlsx`
+PYCOUNTRY_NAME_OVERRIDE = {
+    "Bolivia, Plurinational State of": "Bolivia",
+    "Holy See (Vatican City State)": "Vatican",
+    "Micronesia, Federated States of": "Micronesia",
+    "Congo, The Democratic Republic of the": "Democratic Republic of the Congo",
+    "Iran, Islamic Republic of": "Iran",
+    "Korea, Republic of": "South Korea",
+    "Korea, Democratic People's Republic of": "North Korea",
+    "Lao People's Democratic Republic": "Laos",
+    "Syrian Arab Republic": "Syria",
+    "Moldova, Republic of": "Moldova",
+    "Tanzania, United Republic of": "Tanzania",
+    "Venezuela, Bolivarian Republic of": "Venezuela",
+    "Palestine, State of": "Palestine",
+    "Taiwan, Province of China": "Taiwan",
+}
+PYCOUNTRY_NAME_ADD = [
+    dict(
+        name="Kosovo",
+        note="Kosovo recognized under UNSC resolution 1244, alpha_3 code not assigned"
+    ),
+]
+
+
+class Countries(pycountry.ExistingCountries):
+    """List of countries based on ISO 3166 database with simplications"""
+
+    def __init__(self):
+
+        super().__init__(os.path.join(pycountry.DATABASE_DIR, "iso3166-1.json"))
+
+        # modify country names
+        for iso_name, nc_name in PYCOUNTRY_NAME_OVERRIDE.items():
+            obj = self.get(name=iso_name)
+            obj.name = nc_name
+            obj.iso_name = iso_name
+            obj.note = "Name changed from ISO 3166 in line with community standards"
+            self.indices["name"][nc_name.lower()] = obj
+
+        # add countries that are not officially recognized
+        # but relevant for IAM community
+        for entry in PYCOUNTRY_NAME_ADD:
+            obj = self.data_class(**entry)
+            self.objects.append(obj)
+
+            for key, value in entry.items():
+                # Lookups and searches are case insensitive. Normalize here.
+                value = value.lower()
+                if key in self.no_index:
+                    continue
+                index = self.indices.setdefault(key, {})
+                if value in index:
+                    raise ValueError(f"Index conflict for country {key}: {value}")
+                index[value] = obj
+
+
+# Initialize `countries` for direct access via API and in codelist module
+countries = Countries()

--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -1,5 +1,9 @@
 import os
+import logging
+
 import pycountry
+
+logger = logging.getLogger(__name__)
 
 # `nomenclature` uses pycountry to (optionally) add all countries and ISO3 codes
 # For readability and in line with conventions of the IAMC community,
@@ -24,16 +28,21 @@ PYCOUNTRY_NAME_OVERRIDE = {
 PYCOUNTRY_NAME_ADD = [
     dict(
         name="Kosovo",
-        note="Kosovo recognized under UNSC resolution 1244, alpha_3 code not assigned"
+        note="Kosovo recognized under UNSC resolution 1244, alpha_3 code not assigned",
     ),
 ]
+
+# the European Commission uses alternative ISO2 codes
+ALTERNATIVE_ALPHA2_CODES = {
+    "EL": "GR",
+    "UK": "GB",
+}
 
 
 class Countries(pycountry.ExistingCountries):
     """List of countries based on ISO 3166 database with simplications"""
 
     def __init__(self):
-
         super().__init__(os.path.join(pycountry.DATABASE_DIR, "iso3166-1.json"))
 
         # modify country names
@@ -59,6 +68,30 @@ class Countries(pycountry.ExistingCountries):
                 if value in index:
                     raise ValueError(f"Index conflict for country {key}: {value}")
                 index[value] = obj
+
+    def get(self, **kwargs):
+        """Get a specific country by attribute
+
+        Parameters
+        ----------
+        name : str
+            Country name
+        alpha_3 : str
+            Alpha-2 code (ISO3)
+        alpha_2 : str
+            Alpha-2 code (ISO2)
+        """
+        country = super().get(**kwargs)
+
+        # special handling for alpha-2 codes used by the European Commission
+        if country is None and "alpha_2" in kwargs:
+            country = super().get(alpha_2=ALTERNATIVE_ALPHA2_CODES[kwargs["alpha_2"]])
+            if country is not None:
+                logger.info(
+                    f"You are using non-standard alpha-2 codes for {country.name}."
+                )
+
+        return country
 
 
 # Initialize `countries` for direct access via API and in codelist module

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -23,9 +23,7 @@ def test_countries_add():
         countries.get(name="Kosovo").alpha_3
 
 
-@pytest.mark.parametrize(
-    "alpha_2_eu, alpha_2", [("EL", "GR"), ("UK", "GB")]
-)
+@pytest.mark.parametrize("alpha_2_eu, alpha_2", [("EL", "GR"), ("UK", "GB")])
 def test_alternative_alpha2(alpha_2_eu, alpha_2):
     """Check that the handling of alternative alpha-2 codes works"""
     assert countries.get(alpha_2=alpha_2_eu).alpha_2 == alpha_2

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -1,0 +1,23 @@
+import pytest
+
+from nomenclature import countries
+
+
+@pytest.mark.parametrize(
+    "nc_name, iso_name, alpha_3",
+    [("Bolivia", "Bolivia, Plurinational State of", "BOL")],
+)
+def test_countries_override(nc_name, iso_name, alpha_3):
+    """Check that countries renamed from ISO 3166 can be found in both directions"""
+
+    assert countries.get(name=nc_name).alpha_3 == "BOL"
+    assert countries.get(name=iso_name).alpha_3 == "BOL"
+    assert countries.get(alpha_3=alpha_3).name == nc_name
+
+
+def test_countries_add():
+    """Check that countries added to ISO 3166 can be found"""
+
+    assert countries.get(name="Kosovo").name == "Kosovo"
+    with pytest.raises(AttributeError):
+        countries.get(name="Kosovo").alpha_3

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -21,3 +21,11 @@ def test_countries_add():
     assert countries.get(name="Kosovo").name == "Kosovo"
     with pytest.raises(AttributeError):
         countries.get(name="Kosovo").alpha_3
+
+
+@pytest.mark.parametrize(
+    "alpha_2_eu, alpha_2", [("EL", "GR"), ("UK", "GB")]
+)
+def test_alternative_alpha2(alpha_2_eu, alpha_2):
+    """Check that the handling of alternative alpha-2 codes works"""
+    assert countries.get(alpha_2=alpha_2_eu).alpha_2 == alpha_2


### PR DESCRIPTION
Per a suggestion by @willu47, this PR adds a shim of the **pycountry.countries** feature offering a simple translation between country names (as commonly used in the modelling community) and alpha-3/alpha-2 codes including the special use of alpha-2 by the European Commission.