### PR TITLE
Import (region) definitions from other repository

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -589,24 +589,18 @@ class RegionCodeList(CodeList):
                     )
                 for c in PYCOUNTRY_NAME_ADD:
                     code_list.append(RegionCode(name=c, hierarchy="Country"))
+            if repo := config.region.repository:
+                repo_path = path.parents[1] / repo
+                if not repo_path.exists():
+                    raise FileNotFoundError(f"Repository not found: {repo}")
+                code_list = cls._parse_region_code_dir(
+                    code_list, repo_path, file_glob_pattern, repository=repo
+                )
+                code_list = cls._parse_and_replace_tags(
+                    code_list, repo_path, file_glob_pattern
+                )
 
         code_list = cls._parse_region_code_dir(code_list, path, file_glob_pattern)
-            f
-            for f in path.glob(file_glob_pattern)
-            if f.suffix in {".yaml", ".yml"} and not f.name.startswith("tag_")
-        ):
-            with open(yaml_file, "r", encoding="utf-8") as stream:
-                _code_list = yaml.safe_load(stream)
-
-            # a "region" codelist assumes a top-level category to be used as attribute
-            for top_level_cat in _code_list:
-                for top_key, _codes in top_level_cat.items():
-                    for item in _codes:
-                        code = RegionCode.from_dict(item)
-                        code.hierarchy = top_key
-                        code.file = yaml_file.relative_to(path.parent).as_posix()
-                        code_list.append(code)
-
         code_list = cls._parse_and_replace_tags(code_list, path, file_glob_pattern)
 
         mapping: Dict[str, RegionCode] = {}

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -5,11 +5,15 @@ from pydantic import BaseModel
 import yaml
 
 
-class RegionCodeListConfig(BaseModel):
+class CodeListConfig(BaseModel):
+    repository: Optional[Path]
+
+
+class RegionCodeListConfig(CodeListConfig):
     country: Optional[bool]
 
 
-class DataStructureConfig(BaseModel):
+class DataStructureConfig(CodeListConfig):
     """A class for configuration of a DataStructureDefinition
 
     Attributes

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -13,7 +13,7 @@ class RegionCodeListConfig(CodeListConfig):
     country: Optional[bool]
 
 
-class DataStructureConfig(CodeListConfig):
+class DataStructureConfig(BaseModel):
     """A class for configuration of a DataStructureDefinition
 
     Attributes

--- a/tests/data/general-config-definitions/config.yaml
+++ b/tests/data/general-config-definitions/config.yaml
@@ -1,2 +1,3 @@
 region:
+  repository: validation_nc/region
   country: true

--- a/tests/data/general-config-definitions/region/regions.yaml
+++ b/tests/data/general-config-definitions/region/regions.yaml
@@ -1,2 +1,2 @@
 - common:
-  - World
+  - Region A

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -47,6 +47,8 @@ def test_definition_from_general_config():
     )
 
     # explicitly defined in `general-config-definitions/region/regions.yaml`
+    assert "Region A" in obs.region
+    # imported from `validation_nc` repo
     assert "World" in obs.region
     # added via general-config definitions
     assert "Austria" in obs.region


### PR DESCRIPTION
This PR adds an option to import a list of codes from another repository, via an attribute `repository` in the general-config of a DataStructureDefinition (currently only implemented and tested for the RegionCodeList).

To be further discussed for the configuration and use cases:

1. The current implementation assumes that an external repository is cloned at the same level as the workflow repository, i.e., to import "common-definitions" into "openentrance", both repositories have to be cloned at the same directory-level. The argument in config would have to read:
    ```yaml
    region:
      repository: common-definitions/definitions/region
    ````

2. The current implementation imports all definitions from the other repository. We can think about adding filters or explicit lists later (once actually needed).
