### PR TITLE
Include definitions from GitHub repo

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -198,8 +198,8 @@ class CodeList(BaseModel):
             codelistconfig = getattr(config, dimension, None)
             if codelistconfig is not None and codelistconfig.repository is not None:
                 repo_path = (
-                    config.repository[codelistconfig.repository].path
-                    / codelistconfig.repository_definition_path
+                    config.repository[codelistconfig.repository].local_path
+                    / codelistconfig.repository_dimension_path
                 )
                 code_list.extend(
                     cls._parse_codelist_dir(
@@ -587,8 +587,8 @@ class RegionCodeList(CodeList):
             # importing from an external repository
             if config.region.repository:
                 repo_path = (
-                    config.repository[config.region.repository].path
-                    / config.region.repository_definition_path
+                    config.repository[config.region.repository].local_path
+                    / config.region.repository_dimension_path
                 )
 
                 code_list = cls._parse_region_code_dir(

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -9,7 +9,7 @@ from pyam.utils import write_sheet
 from pydantic import BaseModel, validator
 
 from nomenclature.code import Code, MetaCode, RegionCode, VariableCode
-from nomenclature.config import DataStructureConfig
+from nomenclature.config import CodeListConfig, RegionCodeListConfig
 from nomenclature.countries import countries
 from nomenclature.error.codelist import DuplicateCodeError
 from nomenclature.error.variable import (
@@ -170,7 +170,7 @@ class CodeList(BaseModel):
         cls,
         name: str,
         path: Path,
-        config: DataStructureConfig = None,
+        config: CodeListConfig = None,
         file_glob_pattern: str = "**/*",
     ):
         """Initialize a CodeList from a directory with codelist files
@@ -181,7 +181,7 @@ class CodeList(BaseModel):
             Name of the CodeList
         path : :class:`pathlib.Path` or path-like
             Directory with the codelist files
-        config: :class:`DataStructureConfig`, optional
+        config: :class:`CodeListConfig`, optional
             Attributes for configuring the CodeList
         file_glob_pattern : str, optional
             Pattern to downselect codelist files by name
@@ -525,7 +525,7 @@ class RegionCodeList(CodeList):
         cls,
         name: str,
         path: Path,
-        config: DataStructureConfig = None,
+        config: RegionCodeListConfig = None,
         file_glob_pattern: str = "**/*",
     ):
         """Initialize a RegionCodeList from a directory with codelist files
@@ -536,7 +536,7 @@ class RegionCodeList(CodeList):
             Name of the CodeList
         path : :class:`pathlib.Path` or path-like
             Directory with the codelist files
-        config : :class:`DataStructureConfig`, optional
+        config : :class:`RegionCodeListConfig`, optional
             Attributes for configuring the CodeList
         file_glob_pattern : str, optional
             Pattern to downselect codelist files by name, default: "**/*" (i.e. all
@@ -551,9 +551,9 @@ class RegionCodeList(CodeList):
         code_list: List[RegionCode] = []
 
         # initializing from general configuration
-        if config is not None and config.region is not None:
+        if config is not None:
             # adding all countries
-            if config.region.country is True:
+            if config.country is True:
                 for c in countries:
                     try:
                         code_list.append(

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -566,15 +566,18 @@ class RegionCodeList(CodeList):
                         code_list.append(RegionCode(name=c.name, hierarchy="Country"))
 
             # importing from an external repository
-            if repo := config.region.repository:
-                repo_path = path.parents[1] / repo
-                if not repo_path.exists():
-                    raise FileNotFoundError(f"Repository not found: {repo}")
+            if config.repository:
+                repo_path = path.parent / config.repository_name
+                config.fetch_repo(repo_path)
+
                 code_list = cls._parse_region_code_dir(
-                    code_list, repo_path, file_glob_pattern, repository=repo
+                    code_list,
+                    repo_path / "definitions" / "region",
+                    file_glob_pattern,
+                    repository=config.repository,
                 )
                 code_list = cls._parse_and_replace_tags(
-                    code_list, repo_path, file_glob_pattern
+                    code_list, repo_path / "definitions" / "region", file_glob_pattern
                 )
 
         # parse from current repository

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 from pydantic import BaseModel, root_validator
 
 import yaml

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -1,12 +1,44 @@
 from pathlib import Path
 from typing import Dict, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 
 import yaml
+from git import Repo
 
 
 class CodeListConfig(BaseModel):
-    repository: Optional[Path]
+    repository: Optional[str]
+    hash: Optional[str]
+    release: Optional[str]
+
+    @root_validator()
+    def check_hash_and_release(cls, v):
+        if v.get("hash") and v.get("release"):
+            raise ValueError("Either 'hash' or 'release' can be provided, not both.")
+        return v
+
+    @property
+    def revision(self):
+        return self.hash or self.release or "main"
+
+    @property
+    def repository_name(self):
+        return self.repository.split("/")[-1].split(".")[0]
+
+    def fetch_repo(self, to_path="./common-definitions"):
+        to_path = to_path if isinstance(to_path, Path) else Path(to_path)
+
+        if not to_path.is_dir():
+            repo = Repo.clone_from(self.repository, to_path)
+        else:
+            repo = Repo(to_path)
+            repo.remotes.origin.fetch()
+        repo.git.reset("--hard")
+        repo.git.checkout(self.revision)
+        repo.git.reset("--hard")
+        repo.git.clean("-xdf")
+        if self.revision == "main":
+            repo.remotes.origin.pull()
 
 
 class RegionCodeListConfig(CodeListConfig):

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -9,7 +9,7 @@ from git import Repo
 class CodeListConfig(BaseModel):
     dimension: str
     repository: Optional[str]
-    repository_definition_path: Optional[str]
+    repository_dimension_path: Optional[Path]
 
     @root_validator()
     def set_repository_definition_path(cls, v):
@@ -29,7 +29,7 @@ class Repository(BaseModel):
     url: str
     hash: Optional[str]
     release: Optional[str]
-    path: Optional[Path]
+    local_path: Optional[Path]  # defined via the `repository` name in the configuration
 
     @root_validator()
     def check_hash_and_release(cls, v):
@@ -40,7 +40,7 @@ class Repository(BaseModel):
     @validator("path")
     def check_path_empty(cls, v):
         if v is not None:
-            raise ValueError("path must not be set as part of the config")
+            raise ValueError("The `path` must not be set as part of the config.")
         return v
 
     @property
@@ -95,8 +95,8 @@ class DataStructureConfig(BaseModel):
             ):
                 raise ValueError(
                     (
-                        f"Unknown repository {values.get(dimension).repository} in"
-                        " region.repository."
+                        f"Unknown repository '{values.get(dimension).repository}' in"
+                        f" {dimension}.repository."
                     )
                 )
         return values

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -23,7 +23,7 @@ class CodeListConfig(BaseModel):
 
     @property
     def repository_name(self):
-        return self.repository.split("/")[-1].split(".")[0]
+        return self.repository.split("/")[-2].split(".")[0]
 
     def fetch_repo(self, to_path="./common-definitions"):
         to_path = to_path if isinstance(to_path, Path) else Path(to_path)

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict
 from pydantic import BaseModel, root_validator, validator
 
 import yaml
@@ -74,7 +74,7 @@ class DataStructureConfig(BaseModel):
 
     """
 
-    repository: dict[str, Repository] = {}
+    repository: Dict[str, Repository] = {}
     region: Optional[RegionCodeListConfig]
     variable: Optional[CodeListConfig]
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -12,12 +12,12 @@ class CodeListConfig(BaseModel):
     repository_dimension_path: Optional[Path]
 
     @root_validator()
-    def set_repository_definition_path(cls, v):
+    def set_repository_dimension_path(cls, v):
         if (
             v.get("repository") is not None
-            and v.get("repository_definition_path") is None
+            and v.get("repository_dimension_path") is None
         ):
-            v["repository_definition_path"] = f"definitions/{v['dimension']}"
+            v["repository_dimension_path"] = f"definitions/{v['dimension']}"
         return v
 
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -37,10 +37,10 @@ class Repository(BaseModel):
             raise ValueError("Either 'hash' or 'release' can be provided, not both.")
         return v
 
-    @validator("path")
+    @validator("local_path")
     def check_path_empty(cls, v):
         if v is not None:
-            raise ValueError("The `path` must not be set as part of the config.")
+            raise ValueError("The `local_path` must not be set as part of the config.")
         return v
 
     @property
@@ -55,7 +55,7 @@ class Repository(BaseModel):
         else:
             repo = Repo(to_path)
             repo.remotes.origin.fetch()
-        self.path = to_path
+        self.local_path = to_path
         repo.git.reset("--hard")
         repo.git.checkout(self.revision)
         repo.git.reset("--hard")

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -50,16 +50,13 @@ class DataStructureDefinition:
                 file="config.yaml",
             )
         else:
-            self.config = DataStructureConfig()
-
+            self.config = None
         self.dimensions = dimensions or ["region", "variable"]
         for dim in self.dimensions:
             codelist_cls = SPECIAL_CODELIST.get(dim, CodeList)
             self.__setattr__(
                 dim,
-                codelist_cls.from_directory(
-                    dim, path / dim, getattr(self.config, dim, None)
-                ),
+                codelist_cls.from_directory(dim, path / dim, self.config),
             )
 
         empty = [d for d in self.dimensions if not self.__getattribute__(d)]

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -56,7 +56,10 @@ class DataStructureDefinition:
         for dim in self.dimensions:
             codelist_cls = SPECIAL_CODELIST.get(dim, CodeList)
             self.__setattr__(
-                dim, codelist_cls.from_directory(dim, path / dim, self.config)
+                dim,
+                codelist_cls.from_directory(
+                    dim, path / dim, getattr(self.config, dim, None)
+                ),
             )
 
         empty = [d for d in self.dimensions if not self.__getattribute__(d)]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     pandas >= 1.5.2
     numpy
     pycountry
+    gitpython
 setup_requires =
     setuptools >= 41
     setuptools_scm

--- a/tests/data/general-config-definitions/config.yaml
+++ b/tests/data/general-config-definitions/config.yaml
@@ -1,3 +1,9 @@
+repository:
+  common-definitions:
+    url: https://github.com/IAMconsortium/common-definitions.git/
 region:
-  repository: https://github.com/IAMconsortium/common-definitions.git/
+  repository: common-definitions
   country: true
+variable:
+  repository: common-definitions
+  path: definitions / variable

--- a/tests/data/general-config-definitions/config.yaml
+++ b/tests/data/general-config-definitions/config.yaml
@@ -1,3 +1,3 @@
 region:
-  repository: validation_nc/region
+  repository: git@github.com:IAMconsortium/common-definitions.git
   country: true

--- a/tests/data/general-config-definitions/config.yaml
+++ b/tests/data/general-config-definitions/config.yaml
@@ -6,4 +6,4 @@ region:
   country: true
 variable:
   repository: common-definitions
-  path: definitions / variable
+  repository_dimension_path: definitions/variable

--- a/tests/data/general-config-definitions/config.yaml
+++ b/tests/data/general-config-definitions/config.yaml
@@ -1,3 +1,3 @@
 region:
-  repository: git@github.com:IAMconsortium/common-definitions.git
+  repository: https://github.com/IAMconsortium/common-definitions.git/
   country: true

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -63,8 +63,8 @@ def test_definition_from_general_config():
     finally:
         # clean up the external repo
         for repository in obs.config.repository.values():
-            if repository.path.exists():
-                shutil.rmtree(repository.path, ignore_errors=True)
+            if repository.local_path.exists():
+                shutil.rmtree(repository.local_path, ignore_errors=True)
 
 
 def test_to_excel(simple_definition, tmpdir):

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -58,6 +58,7 @@ def test_definition_from_general_config():
         # added via general-config definitions in addition to pycountry.countries
         assert "Kosovo" in obs.region
 
+        # imported from https://github.com/IAMconsortium/common-definitions repo
         assert "Primary Energy" in obs.variable
     finally:
         # clean up the external repo

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -1,3 +1,4 @@
+import shutil
 import pytest
 import pandas as pd
 from nomenclature import DataStructureDefinition, create_yaml_from_xlsx
@@ -45,17 +46,26 @@ def test_definition_from_general_config():
         TEST_DATA_DIR / "general-config-definitions",
         dimensions=["region"],
     )
-
-    # explicitly defined in `general-config-definitions/region/regions.yaml`
-    assert "Region A" in obs.region
-    # imported from `validation_nc` repo
-    assert "World" in obs.region
-    # added via general-config definitions
-    assert "Austria" in obs.region
-    # added via general-config definitions renamed from pycountry name
-    assert "Bolivia" in obs.region
-    # added via general-config definitions in addition to pycountry.countries
-    assert "Kosovo" in obs.region
+    try:
+        # explicitly defined in `general-config-definitions/region/regions.yaml`
+        assert "Region A" in obs.region
+        # imported from https://github.com/IAMconsortium/common-definitions repo
+        assert "World" in obs.region
+        # added via general-config definitions
+        assert "Austria" in obs.region
+        # added via general-config definitions renamed from pycountry name
+        assert "Bolivia" in obs.region
+        # added via general-config definitions in addition to pycountry.countries
+        assert "Kosovo" in obs.region
+    finally:
+        # clean up the external repo
+        repo_dir = (
+            TEST_DATA_DIR
+            / "general-config-definitions"
+            / obs.config.region.repository_name
+        )
+        if repo_dir.exists():
+            shutil.rmtree(repo_dir)
 
 
 def test_to_excel(simple_definition, tmpdir):

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -44,7 +44,7 @@ def test_empty_codelist_raises():
 def test_definition_from_general_config():
     obs = DataStructureDefinition(
         TEST_DATA_DIR / "general-config-definitions",
-        dimensions=["region"],
+        dimensions=["region", "variable"],
     )
     try:
         # explicitly defined in `general-config-definitions/region/regions.yaml`
@@ -57,15 +57,13 @@ def test_definition_from_general_config():
         assert "Bolivia" in obs.region
         # added via general-config definitions in addition to pycountry.countries
         assert "Kosovo" in obs.region
+
+        assert "Primary Energy" in obs.variable
     finally:
         # clean up the external repo
-        repo_dir = (
-            TEST_DATA_DIR
-            / "general-config-definitions"
-            / obs.config.region.repository_name
-        )
-        if repo_dir.exists():
-            shutil.rmtree(repo_dir)
+        for repository in obs.config.repository.values():
+            if repository.path.exists():
+                shutil.rmtree(repository.path, ignore_errors=True)
 
 
 def test_to_excel(simple_definition, tmpdir):


### PR DESCRIPTION
First version of the external repo fetching feature.

### How to use
In the `definitions` folder of a project place a file called definitions with the following content:

```yaml
region:
  repository: https://github.com/IAMconsortium/common-definitions.git/
  # hash: optionally specify a commit hash of the repository
  # release: optionally specify a release of the repository
```
the `hash` and `release` attributes are both optional. 
If neither is given, the last version of the main branch is used. 
They are also mutually exclusive. If both are given an error is raised.

### Implementation details

The repo fetching logic is implemented as follows:
1. If the repo is not present, clone it
2. Perform a hard reset to get rid of any changes
3. Check out the desired revision