### PR TITLE
Improve the docs of the countries feature

### DIFF
--- a/docs/api/countries.rst
+++ b/docs/api/countries.rst
@@ -13,15 +13,19 @@ The :class:`nomenclature` package builds on the :class:`pycountry` package
 (`link <https://github.com/flyingcircusio/pycountry>`_) to provide a utility for country
 names based on the ISO 3166-1 standard.
 
-For consistency with conventions in the modelling community, several country names are
-shortened compared to ISO 3166-1 , e.g. from "Bolivia, Plurinational State of" to "Bolivia".
-Also, "Kosovo" is added even though it is not a universally recognized state.
-See the full list of changes on GitHub_.
+For consistency with established conventions in the modelling community, several country
+names are shortened compared to ISO 3166-1, e.g. from "Bolivia, Plurinational State of"
+to "Bolivia". Also, "Kosovo" is added even though it is not a universally recognized
+state. See the full list of changes on GitHub_.
 
-You can use this utility for mapping between country names as used in the community
+You can access the list of countries via the model registration `Excel template`_.
+
+You can also use this utility for mapping between country names as used in the community
 and alpha-3 or alpha-2 codes, as shown in this example.
 
 .. _GitHub: https://github.com/IAMconsortium/nomenclature/blob/main/nomenclature/countries.py
+
+.. _`Excel template`: https://raw.githubusercontent.com/IAMconsortium/nomenclature/main/templates/model-registration-template.xlsx
 
 .. code:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,9 @@ for example, a "variable" has to have an expected unit and usually has a descrip
 Read the `SDMX Guidelines <https://sdmx.org/?page_id=4345>`_ for more information on
 the concept of codelists.
 
+Validation and region-processing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The **nomenclature** package supports three main use cases:
 
 - Management of codelists and mappings for model comparison projects
@@ -49,6 +52,9 @@ The **nomenclature** package supports three main use cases:
 
 The codelists and mappings are stored as yaml files.
 Refer to the :ref:`user_guide` for more information.
+
+Utility for country names and abbreviations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The **nomenclature** package also provides a utility for translating between country
 names (as commonly used in the modelling community) and alpha-3/alpha-2 codes (also

--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -77,9 +77,14 @@ class Countries(pycountry.ExistingCountries):
         name : str
             Country name
         alpha_3 : str
-            Alpha-2 code (ISO3)
+            Alpha-3 code (ISO3)
         alpha_2 : str
             Alpha-2 code (ISO2)
+
+        Returns
+        -------
+        :class:`pycountry.Country`
+
         """
         country = super().get(**kwargs)
 


### PR DESCRIPTION
This PR adds a link to the model-registration Excel to the countries-module docs for users who want an easy (non-Python) way to get the ist of countries.