### PR TITLE
Rename US/British Virgin Islands in `countries` module

### DIFF
--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -24,6 +24,8 @@ PYCOUNTRY_NAME_OVERRIDE = {
     "Venezuela, Bolivarian Republic of": "Venezuela",
     "Palestine, State of": "Palestine",
     "Taiwan, Province of China": "Taiwan",
+    "Virgin Islands, British": "British Virgin Islands",
+    "Virgin Islands, U.S.": "United States Virgin Islands",
 }
 PYCOUNTRY_NAME_ADD = [
     dict(


### PR DESCRIPTION
Working with the SSP-review and common-definitions, I noticed that the ISO 3166-1 names for the US and British Virgin Islands are not elegant to work with in a yaml format due to comma or brackets. For simplicity, this PR adds these two countries to the replace-mapping.