### PR TITLE
Refactor MetaValidator tests to not use `exclude` indicator 

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,8 +6,9 @@ name: nightly
 
 on:
   schedule:
-    # runs once per week on Sunday at 3am UCT
-    - cron: '0 3 * * 0'
+    # see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
+    # 05:00 UTC = 06:00 CET = 07:00 CEST
+    - cron: "0 5 * * TUE"
 jobs:
   pytest:
 

--- a/nomenclature/processor/meta.py
+++ b/nomenclature/processor/meta.py
@@ -45,9 +45,8 @@ class MetaValidator(Processor):
         not_allowed = [value for value in values if value not in allowed_values]
         if not_allowed:
             raise ValueError(
-                f"{not_allowed} meta indicator value(s) in the {meta_indicator} "
-                "column are not allowed. Allowed values are "
-                f"{allowed_values}"
+                f"Invalid value for meta indicator '{meta_indicator}': {repr_list(not_allowed)}\n"
+                f"Allowed values: {repr_list(allowed_values)}"
             )
         return True
 
@@ -72,15 +71,14 @@ class MetaValidator(Processor):
             definition file
         """
 
-        if unrecognized_meta_indicators := [
+        if invalid_meta_indicators := [
             meta_indicator
             for meta_indicator in df.meta.columns
             if meta_indicator not in self.meta_code_list.mapping
         ]:
             raise ValueError(
-                f"{unrecognized_meta_indicators} is/are not recognized in the "
-                f"meta definitions file. Allowed meta indicators are: "
-                f"{list(self.meta_code_list.mapping.keys())}"
+                f"Invalid meta indicator: {repr_list(invalid_meta_indicators)}\n"
+                f"Valid meta indicators: {repr_list(self.meta_code_list.mapping.keys())}"
             )
 
         for meta_indicator in df.meta.columns:
@@ -90,3 +88,7 @@ class MetaValidator(Processor):
                 meta_indicator,
             )
         return df
+
+
+def repr_list(x):
+    return "'" + "', '".join(map(str, x)) + "'"

--- a/tests/data/definitions2/meta/meta_indicators_test_data.yaml
+++ b/tests/data/definitions2/meta/meta_indicators_test_data.yaml
@@ -1,4 +1,4 @@
-- Not exclude:
+- boolean:
     allowed_values: [True, False]
 - number:
     allowed_values: [1.0, 2.0, 3.0, 4.0]

--- a/tests/data/definitions3/meta/meta_indicators_more_data.yaml
+++ b/tests/data/definitions3/meta/meta_indicators_more_data.yaml
@@ -1,4 +1,4 @@
-- exclude:
+- meta_string:
     allowed_values: ['A', 'B']
 - number:
     allowed_values: [1.0, 2.0, 3.0, 4.0]

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -13,11 +13,12 @@ def test_MetaValidator(simple_df):
 
 
 def test_MetaValidator_Meta_Indicator_Error(simple_df):
-    path = Path(TEST_DATA_DIR / "definitions2/meta")
+    path = Path(TEST_DATA_DIR / "definitions2" / "meta")
+    simple_df.set_meta(name="not allowed", meta=False)
     meta_validator = MetaValidator(path_to_meta_code_list_files=path)
     match = (
-        "\['exclude'\] is/are not recognized in the meta definitions file. "  # noqa
-        "Allowed meta indicators are: \['Not exclude', 'number', 'string'\]"  # noqa
+        "Invalid meta indicator: 'not allowed'\n"  # noqa
+        "Valid meta indicators: 'boolean', 'number', 'string'"  # noqa
     )
 
     with pytest.raises(ValueError, match=match):
@@ -25,11 +26,12 @@ def test_MetaValidator_Meta_Indicator_Error(simple_df):
 
 
 def test_MetaValidator_Meta_Indicator_Value_Error(simple_df):
-    path = Path(TEST_DATA_DIR / "definitions3/meta")
+    path = Path(TEST_DATA_DIR / "definitions3" / "meta")
+    simple_df.set_meta(name="meta_string", meta=3)
     meta_validator = MetaValidator(path_to_meta_code_list_files=path)
     match = (
-        "\[False\] meta indicator value\(s\) in the "  # noqa
-        "exclude column are not allowed. Allowed values are \['A', 'B'\]"  # noqa
+        "Invalid value for meta indicator 'meta_string': '3'\n"  # noqa
+        "Allowed values: 'A', 'B'"  # noqa
     )
     with pytest.raises(ValueError, match=match):
         meta_validator.apply(df=simple_df)


### PR DESCRIPTION
This PR implements the change that the pyam-meta-attribute does not (any more) have an indicator `exclude`.

This PR is not compatible with the latest release-version of pyam, but I think that this is not a concern because:
- the pypi-release-versions are compatible
- the latest versions on GitHub are compatible
- we add a dependency on pyam>2.0 in nomenclature after the next release