### PR TITLE
Extend the `Countries` docstring

### DIFF
--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -42,7 +42,6 @@ ALTERNATIVE_ALPHA2_CODES = {
 
 
 class Countries(pycountry.ExistingCountries):
-
     """List of countries based on simplified ISO 3166 database
 
     This list follows the :class:`nomenclature.countries` module based on

--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -42,8 +42,13 @@ ALTERNATIVE_ALPHA2_CODES = {
 
 
 class Countries(pycountry.ExistingCountries):
-    """List of countries based on ISO 3166 database with simplications"""
 
+    """List of countries based on simplified ISO 3166 database
+
+    This list follows the :class:`nomenclature.countries` module based on
+    country names using ISO 3166-1, but it simplifies several country names
+    for readability and in line with conventions of the IAMC community.
+    """
     def __init__(self):
         super().__init__(os.path.join(pycountry.DATABASE_DIR, "iso3166-1.json"))
 

--- a/nomenclature/countries.py
+++ b/nomenclature/countries.py
@@ -49,6 +49,7 @@ class Countries(pycountry.ExistingCountries):
     country names using ISO 3166-1, but it simplifies several country names
     for readability and in line with conventions of the IAMC community.
     """
+
     def __init__(self):
         super().__init__(os.path.join(pycountry.DATABASE_DIR, "iso3166-1.json"))
 


### PR DESCRIPTION
Starting from a simple typo-correction, this PR adds a few lines of explanation to the **Countries** docstring.

Note that a more detailed explanation is already given via the module-page on readthedocs, see https://nomenclature-iamc.readthedocs.io/en/stable/api/countries.html