### PR TITLE
Update pyam-imports prior to pyam v2.0

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -1,13 +1,12 @@
 import json
 import re
-import pyam
 import pycountry
 from keyword import iskeyword
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
-
 from pydantic import BaseModel, Field, validator
 
+from pyam.utils import to_list
 
 class Code(BaseModel):
     """A simple class for a mapping of a "code" to its attributes"""
@@ -230,7 +229,7 @@ class RegionCode(Code):
         """Verifies that each ISO3 code is valid according to pycountry library."""
         if invalid_iso3_codes := [
             iso3_code
-            for iso3_code in pyam.to_list(v)
+            for iso3_code in to_list(v)
             if pycountry.countries.get(alpha_3=iso3_code) is None
         ]:
             raise ValueError(

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, validator
 
 from pyam.utils import to_list
 
+
 class Code(BaseModel):
     """A simple class for a mapping of a "code" to its attributes"""
 

--- a/nomenclature/validation.py
+++ b/nomenclature/validation.py
@@ -1,5 +1,6 @@
 import logging
-from pyam import IamDataFrame, to_list
+from pyam import IamDataFrame
+from pyam.utils import to_list
 
 # define logger for this script at logging level INFO
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import pytest
 import shutil
 import pandas as pd
-from pyam import IamDataFrame, IAMC_IDX
+from pyam import IamDataFrame
+from pyam.utils import IAMC_IDX
 from nomenclature import DataStructureDefinition
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,8 @@ from pandas.testing import assert_frame_equal
 from nomenclature.core import process
 from nomenclature.definition import DataStructureDefinition
 from nomenclature.processor.region import RegionProcessor
-from pyam import IAMC_IDX, IamDataFrame, assert_iamframe_equal
+from pyam import IamDataFrame, assert_iamframe_equal
+from pyam.utils import IAMC_IDX
 
 from conftest import TEST_DATA_DIR, add_meta
 

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -10,7 +10,8 @@ from nomenclature import (
     process,
 )
 from nomenclature.error.region import RegionAggregationMappingParsingError
-from pyam import IAMC_IDX, IamDataFrame
+from pyam import IamDataFrame
+from pyam.utils import IAMC_IDX
 
 from conftest import TEST_DATA_DIR, clean_up_external_repos
 


### PR DESCRIPTION
This PR implements a few minor import-updates due to the revised exposure of pyam functions/attributes at the top-level (see https://github.com/IAMconsortium/pyam/pull/764).