### PR TITLE
Update supported python versions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # keep consistent with py-version badge in README.md and doc/source/index.rst
         # update setup.cfg and doc/source/installation.rst when deprecating python 3.8
-        python-version: ['3.8', '3.9', '3.10']        
+        python-version: ['3.10', '3.11']
       fail-fast: false
     runs-on: ubuntu-latest
     name: py${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         # keep consistent with py-version badge in README.md and doc/source/index.rst
         # update setup.cfg and doc/source/installation.rst when deprecating python 3.8
-        python-version: ['3.8', '3.9', '3.10']        
+        python-version: ['3.10', '3.11']
         os: [ubuntu, macos, windows]
       fail-fast: false
-    
+
     runs-on: ${{ matrix.os }}-latest
     name: 'OS: ${{matrix.os}} py${{ matrix.python-version }}'
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the [LICENSE](LICENSE) for details.
 
 [![license](https://img.shields.io/badge/License-Apache%202.0-black)](https://github.com/IAMconsortium/nomenclature/blob/main/LICENSE)
 [![DOI](https://zenodo.org/badge/375724610.svg)](https://zenodo.org/badge/latestdoi/375724610)
-[![python](https://img.shields.io/badge/python-3.8_|_3.9_|_3.10-blue?logo=python&logoColor=white)](https://github.com/IAMconsortium/nomenclature)
+[![python](https://img.shields.io/badge/python-3.10_|_3.11-blue?logo=python&logoColor=white)](https://github.com/IAMconsortium/nomenclature)
 [![Code style:
 black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pytest](https://github.com/IAMconsortium/nomenclature/actions/workflows/pytest.yml/badge.svg)](https://github.com/IAMconsortium/nomenclature/actions/workflows/pytest.yml)
@@ -33,7 +33,7 @@ The **nomenclature** package supports three main use cases:
 - Validation of scenario data against the codelists of a specific project
 - Processing of scenario results, e.g. aggregation and renaming from "native regions" of
   a model to "common regions" (i.e., regions that are used for scenario comparison in a project).
-  
+
 The documentation is hosted on [Read the Docs](https://nomenclature-iamc.readthedocs.io/).
 
 ## Integration with the pyam package

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Release v\ |version|.
 .. |doi| image:: https://zenodo.org/badge/375724610.svg
    :target: https://zenodo.org/badge/latestdoi/375724610
 
-.. |python| image:: https://img.shields.io/badge/python-_3.8_|_3.9_|_3.10-blue?logo=python&logoColor=white
+.. |python| image:: https://img.shields.io/badge/python-_3.10|_3.11-blue?logo=python&logoColor=white
    :target: https://github.com/IAMconsortium/nomenclature
 
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ url = https://github.com/IAMconsortium/nomenclature
 [options]
 packages = nomenclature
 include_package_data = True
-python_requires = >= 3.8
+python_requires = >=3.10, <3.12
 install_requires =
     click >= 8
     pyam-iamc >= 1.7.0


### PR DESCRIPTION
As I created #279 I noticed that a number of tests were failing. The ones for python versions 3.8 and 3.9 are failing because the latest version of pyam does not longer support them.
So I updated nomenclature accordingly. 

Note: The tests are currently failing because of the pyam update for the RequiredDataValidator. I'll update that next.