### PR TITLE
Update RequiredDataValidator

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # keep consistent with py-version badge in README.md and doc/source/index.rst
         # update setup.cfg and doc/source/installation.rst when deprecating python 3.8
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10']
       fail-fast: false
     runs-on: ubuntu-latest
     name: py${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # keep consistent with py-version badge in README.md and doc/source/index.rst
         # update setup.cfg and doc/source/installation.rst when deprecating python 3.8
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10']
         os: [ubuntu, macos, windows]
       fail-fast: false
 

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -161,7 +161,7 @@ class RequiredDataValidator(Processor):
         }:
             missing_data_log_info = ""
             for model, data_list in missing_data.items():
-                missing_data_log_info += f"Missing for {model}:\n"
+                missing_data_log_info += f"Missing for '{model}':\n"
                 for data in data_list:
                     missing_data_log_info += f"{data}\n\n"
             logger.error(

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -161,7 +161,7 @@ class RequiredDataValidator(Processor):
             logger.error(
                 "Missing required data.\nFile: %s\nMissing rows:\n\n%s",
                 get_relative_path(self.file),
-                "\n\n".join(str(m.reset_index()) for m in missing_data),
+                "\n\n".join(str(m) for m in missing_data),
             )
             raise RequiredDataMissingError(
                 "Required data missing. Please check the log for details."

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
+import pandas as pd
 import pydantic
 import yaml
 import pyam
@@ -162,21 +163,35 @@ class RequiredDataValidator(Processor):
         return df
 
     def check_required_data_per_model(self, df: IamDataFrame, model: str) -> bool:
-        per_model_data = df.filter(model=model)
+        model_df = df.filter(model=model)
         error = False
-        for data in self.required_data:
-            for requirements in data.pyam_required_data_list:
-                if all(
-                    (missing_index := per_model_data.require_data(**requirement))
-                    is not None
-                    for requirement in requirements
-                ):
-                    error = True
-                    logger.error(
-                        f"Required data {requirements} from file "
-                        f"{get_relative_path(self.file)} missing for:\n"
-                        f"{missing_index}"
+        for requirement in self.required_data:
+            for variable_requirement in requirement.pyam_required_data_list:
+                missing_data_per_unit = [
+                    model_df.require_data(**unit_requirement)
+                    for unit_requirement in variable_requirement
+                ]
+                if all(missing is not None for missing in missing_data_per_unit):
+                    missing_data_per_variable = pd.concat(missing_data_per_unit).astype(
+                        str
                     )
+                    missing_data_columns = missing_data_per_variable.columns.to_list()
+                    # flatten out the last dimension for presentation
+                    missing_data_per_variable = (
+                        missing_data_per_variable.groupby(missing_data_columns[:-1])[
+                            missing_data_columns[-1]
+                        ]
+                        .apply(",".join)
+                        .to_frame()
+                    )
+
+                    if not error:
+                        logger.error(
+                            "Required data from: %s missing: ",
+                            get_relative_path(self.file),
+                        )
+                    logger.warn("\n%s", missing_data_per_variable)
+                    error = True
         return error
 
     def validate_with_definition(self, dsd: DataStructureDefinition) -> None:

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -157,6 +157,7 @@ class RequiredDataValidator(Processor):
         if missing_data := {
             model: list(self.check_required_data_per_model(df, model))
             for model in models_to_check
+            if list(self.check_required_data_per_model(df, model))
         }:
             missing_data_log_info = ""
             for model, data_list in missing_data.items():

--- a/tests/data/required_data/required_data/requiredData_apply_error.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_error.yaml
@@ -4,4 +4,10 @@ required_data:
     - Primary Energy:
         unit: [GWh/yr, Mtoe]
     year: [2005, 2010, 2015] # 2015 is missing from simple_df for all models
+  - variable: Final Energy
+  - measurand:
+    - Emissions|CO2:
+        unit: Mt CO2/yr
+  - variable: Final Energy
+    region: World
 

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -99,13 +99,25 @@ def test_RequiredData_apply_raises(simple_df, caplog):
     with pytest.raises(RequiredDataMissingError, match="Required data missing"):
         required_data_validator.apply(simple_df)
 
-    missing_index = pd.DataFrame(
-        [["model_a", "scen_a"], ["model_a", "scen_b"]], columns=["model", "scenario"]
-    )
+    missing_data = [
+        """
+model_a scen_a   Primary Energy GWh/yr  2005,2010,2015
+                                Mtoe    2005,2010,2015
+        scen_b   Primary Energy GWh/yr  2005,2010,2015
+                                Mtoe    2005,2010,2015""",
+        """
+model_a scen_a    Final Energy
+        scen_b    Final Energy""",
+        """
+model_a scen_a   Emissions|CO2  Mt CO2/yr
+        scen_b   Emissions|CO2  Mt CO2/yr""",
+        """
+model_a scen_a   World   Final Energy
+        scen_b   World   Final Energy""",
+    ]
     # check if the log message contains the correct information
     assert all(
-        x in caplog.text
-        for x in ("ERROR", "Required data", "missing", str(missing_index))
+        x in caplog.text for x in ["ERROR", "Required data", "missing"] + missing_data
     )
 
 

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -101,23 +101,23 @@ def test_RequiredData_apply_raises(simple_df, caplog):
 
     missing_data = [
         """
-   index    model scenario        variable    unit            year
-0      0  model_a   scen_a  Primary Energy  GWh/yr  2005,2010,2015
-1      1  model_a   scen_a  Primary Energy    Mtoe  2005,2010,2015
-2      2  model_a   scen_b  Primary Energy  GWh/yr  2005,2010,2015
-3      3  model_a   scen_b  Primary Energy    Mtoe  2005,2010,2015""",
+     model scenario        variable    unit            year
+0  model_a   scen_a  Primary Energy  GWh/yr  2005,2010,2015
+1  model_a   scen_a  Primary Energy    Mtoe  2005,2010,2015
+2  model_a   scen_b  Primary Energy  GWh/yr  2005,2010,2015
+3  model_a   scen_b  Primary Energy    Mtoe  2005,2010,2015""",
         """
-   index    model scenario      variable
-0      0  model_a   scen_a  Final Energy
-1      1  model_a   scen_b  Final Energy""",
+     model scenario      variable
+0  model_a   scen_a  Final Energy
+1  model_a   scen_b  Final Energy""",
         """
-   index    model scenario       variable       unit
-0      0  model_a   scen_a  Emissions|CO2  Mt CO2/yr
-1      1  model_a   scen_b  Emissions|CO2  Mt CO2/yr""",
+     model scenario       variable       unit
+0  model_a   scen_a  Emissions|CO2  Mt CO2/yr
+1  model_a   scen_b  Emissions|CO2  Mt CO2/yr""",
         """
-   index    model scenario region      variable
-0      0  model_a   scen_a  World  Final Energy
-1      1  model_a   scen_b  World  Final Energy""",
+     model scenario region      variable
+0  model_a   scen_a  World  Final Energy
+1  model_a   scen_b  World  Final Energy""",
     ]
     # check if the log message contains the correct information
     assert all(

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -101,23 +101,28 @@ def test_RequiredData_apply_raises(simple_df, caplog):
 
     missing_data = [
         """
-model_a scen_a   Primary Energy GWh/yr  2005,2010,2015
-                                Mtoe    2005,2010,2015
-        scen_b   Primary Energy GWh/yr  2005,2010,2015
-                                Mtoe    2005,2010,2015""",
+   index    model scenario        variable    unit            year
+0      0  model_a   scen_a  Primary Energy  GWh/yr  2005,2010,2015
+1      1  model_a   scen_a  Primary Energy    Mtoe  2005,2010,2015
+2      2  model_a   scen_b  Primary Energy  GWh/yr  2005,2010,2015
+3      3  model_a   scen_b  Primary Energy    Mtoe  2005,2010,2015""",
         """
-model_a scen_a    Final Energy
-        scen_b    Final Energy""",
+   index    model scenario      variable
+0      0  model_a   scen_a  Final Energy
+1      1  model_a   scen_b  Final Energy""",
         """
-model_a scen_a   Emissions|CO2  Mt CO2/yr
-        scen_b   Emissions|CO2  Mt CO2/yr""",
+   index    model scenario       variable       unit
+0      0  model_a   scen_a  Emissions|CO2  Mt CO2/yr
+1      1  model_a   scen_b  Emissions|CO2  Mt CO2/yr""",
         """
-model_a scen_a   World   Final Energy
-        scen_b   World   Final Energy""",
+   index    model scenario region      variable
+0      0  model_a   scen_a  World  Final Energy
+1      1  model_a   scen_b  World  Final Energy""",
     ]
     # check if the log message contains the correct information
     assert all(
-        x in caplog.text for x in ["ERROR", "Required data", "missing"] + missing_data
+        x in caplog.text
+        for x in ["ERROR", "Missing required data", "File"] + missing_data
     )
 
 

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -101,23 +101,23 @@ def test_RequiredData_apply_raises(simple_df, caplog):
 
     missing_data = [
         """
-     model scenario        variable    unit            year
-0  model_a   scen_a  Primary Energy  GWh/yr  2005,2010,2015
-1  model_a   scen_a  Primary Energy    Mtoe  2005,2010,2015
-2  model_a   scen_b  Primary Energy  GWh/yr  2005,2010,2015
-3  model_a   scen_b  Primary Energy    Mtoe  2005,2010,2015""",
+  scenario        variable    unit            year
+0   scen_a  Primary Energy  GWh/yr  2005,2010,2015
+1   scen_a  Primary Energy    Mtoe  2005,2010,2015
+2   scen_b  Primary Energy  GWh/yr  2005,2010,2015
+3   scen_b  Primary Energy    Mtoe  2005,2010,2015""",
         """
-     model scenario      variable
-0  model_a   scen_a  Final Energy
-1  model_a   scen_b  Final Energy""",
+  scenario      variable
+0   scen_a  Final Energy
+1   scen_b  Final Energy""",
         """
-     model scenario       variable       unit
-0  model_a   scen_a  Emissions|CO2  Mt CO2/yr
-1  model_a   scen_b  Emissions|CO2  Mt CO2/yr""",
+  scenario       variable       unit
+0   scen_a  Emissions|CO2  Mt CO2/yr
+1   scen_b  Emissions|CO2  Mt CO2/yr""",
         """
-     model scenario region      variable
-0  model_a   scen_a  World  Final Energy
-1  model_a   scen_b  World  Final Energy""",
+  scenario region      variable
+0   scen_a  World  Final Energy
+1   scen_b  World  Final Energy""",
     ]
     # check if the log message contains the correct information
     assert all(


### PR DESCRIPTION
This PR updates `RequiredDataValidator` to make use of the pyam update to `require_data` and now presents the missing data accurately.

Example:
```console
ERROR    nomenclature.processor.required_data:required_data.py:189 Required data from: tests/data/required_data/required_data/requiredData_apply_error.yaml missing: 
WARNING  nomenclature.processor.required_data:required_data.py:193 
                                                  year
model   scenario variable       unit                  
model_a scen_a   Primary Energy GWh/yr  2005,2010,2015
        scen_b   Primary Energy GWh/yr  2005,2010,2015
```