### PR TITLE
Raise error for unknown region

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -26,6 +26,7 @@ from nomenclature.error.region import (
 )
 from nomenclature.processor import Processor
 from nomenclature.processor.utils import get_relative_path
+from nomenclature.validation import log_error
 
 logger = logging.getLogger(__name__)
 
@@ -450,7 +451,9 @@ class RegionProcessor(Processor):
                 processed_dfs.append(self._apply_region_processing(model_df)[0])
 
         res = pyam.concat(processed_dfs)
-        self.region_codelist.validate_items(res.region)
+        if not_defined_regions := self.region_codelist.validate_items(res.region):
+            log_error("region", not_defined_regions)
+            raise ValueError("The validation failed. Please check the log for details.")
         return res
 
     def check_region_aggregation(


### PR DESCRIPTION
Closes #283.

This PR adds an error that is raised is case `RegionProcessor` encounters an unknown region.
The reporting is done in the same style as `DataStructureDefinition.validate` does it.

As a side note, I think this was a bit for a corner case, unknown regions would only slip by if the following conditions are met:

* A `RegionProcessor` is used (otherwise `process` validates the regions)
* The unknown regions are attached to a model for which no model mapping is defined. This is because as part of the region processing, the mapping is checked for consistency _and_ and error is raised if input data contain regions that are not mentioned in `native_regions`, `common_regions` or `exclude_regions`

In any case, the bug is fixed now.