### PR TITLE
Fix for general config failing without definitions

### DIFF
--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -46,7 +46,7 @@ class DataStructureDefinition:
         else:
             self.config = None
 
-        if not path.is_dir() and not self.config.repositories:
+        if not path.is_dir() and (self.config is None or not self.config.repositories):
             raise NotADirectoryError(f"Definitions directory not found: {path}")
 
         self.dimensions = dimensions or ["region", "variable"]

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -41,13 +41,14 @@ class DataStructureDefinition:
         if not isinstance(path, Path):
             path = Path(path)
 
-        if not path.is_dir():
-            raise NotADirectoryError(f"Definitions directory not found: {path}")
-
         if (file := path.parent / "nomenclature.yaml").exists():
             self.config = NomenclatureConfig.from_file(file=file)
         else:
             self.config = None
+
+        if not path.is_dir() and not self.config.repositories:
+            raise NotADirectoryError(f"Definitions directory not found: {path}")
+
         self.dimensions = dimensions or ["region", "variable"]
         for dim in self.dimensions:
             codelist_cls = SPECIAL_CODELIST.get(dim, CodeList)

--- a/tests/data/general-config-only/nomenclature.yaml
+++ b/tests/data/general-config-only/nomenclature.yaml
@@ -1,0 +1,10 @@
+repositories:
+  common-definitions:
+    url: https://github.com/IAMconsortium/common-definitions.git/
+definitions:
+  region:
+    repository: common-definitions
+    country: true
+  variable:
+    repository: common-definitions
+    repository_dimension_path: definitions/variable

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -41,16 +41,15 @@ def test_empty_codelist_raises():
         DataStructureDefinition(TEST_DATA_DIR / "simple_codelist")
 
 
-@pytest.mark.parametrize("external_only", [True, False])
-def test_definition_from_general_config(external_only):
-    workflow_folder = "general-config-only" if external_only else "general-config"
+@pytest.mark.parametrize("workflow_folder", ["general-config-only", "general-config"])
+def test_definition_from_general_config(workflow_folder):
     obs = DataStructureDefinition(
         TEST_DATA_DIR / workflow_folder / "definitions",
         dimensions=["region", "variable"],
     )
     try:
         # explicitly defined in `general-config-definitions/region/regions.yaml`
-        if not external_only:
+        if workflow == "general-config":
             assert "Region A" in obs.region
         # imported from https://github.com/IAMconsortium/common-definitions repo
         assert "World" in obs.region

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -49,7 +49,7 @@ def test_definition_from_general_config(workflow_folder):
     )
     try:
         # explicitly defined in `general-config-definitions/region/regions.yaml`
-        if workflow == "general-config":
+        if workflow_folder == "general-config":
             assert "Region A" in obs.region
         # imported from https://github.com/IAMconsortium/common-definitions repo
         assert "World" in obs.region

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -64,6 +64,27 @@ def test_definition_from_general_config():
         clean_up_external_repos(obs.config.repositories)
 
 
+def test_only_definition_from_general_config():
+    obs = DataStructureDefinition(
+        TEST_DATA_DIR / "general-config-only" / "definitions",
+        dimensions=["region", "variable"],
+    )
+    try:
+        # imported from https://github.com/IAMconsortium/common-definitions repo
+        assert "World" in obs.region
+        # added via general-config definitions
+        assert "Austria" in obs.region
+        # added via general-config definitions renamed from pycountry name
+        assert "Bolivia" in obs.region
+        # added via general-config definitions in addition to pycountry.countries
+        assert "Kosovo" in obs.region
+
+        # imported from https://github.com/IAMconsortium/common-definitions repo
+        assert "Primary Energy" in obs.variable
+    finally:
+        clean_up_external_repos(obs.config.repositories)
+
+
 def test_to_excel(simple_definition, tmpdir):
     """Check writing a DataStructureDefinition to file"""
     file = tmpdir / "testing_export.xlsx"

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -41,35 +41,17 @@ def test_empty_codelist_raises():
         DataStructureDefinition(TEST_DATA_DIR / "simple_codelist")
 
 
-def test_definition_from_general_config():
+@pytest.mark.parametrize("external_only", [True, False])
+def test_definition_from_general_config(external_only):
+    workflow_folder = "general-config-only" if external_only else "general-config"
     obs = DataStructureDefinition(
-        TEST_DATA_DIR / "general-config" / "definitions",
+        TEST_DATA_DIR / workflow_folder / "definitions",
         dimensions=["region", "variable"],
     )
     try:
         # explicitly defined in `general-config-definitions/region/regions.yaml`
-        assert "Region A" in obs.region
-        # imported from https://github.com/IAMconsortium/common-definitions repo
-        assert "World" in obs.region
-        # added via general-config definitions
-        assert "Austria" in obs.region
-        # added via general-config definitions renamed from pycountry name
-        assert "Bolivia" in obs.region
-        # added via general-config definitions in addition to pycountry.countries
-        assert "Kosovo" in obs.region
-
-        # imported from https://github.com/IAMconsortium/common-definitions repo
-        assert "Primary Energy" in obs.variable
-    finally:
-        clean_up_external_repos(obs.config.repositories)
-
-
-def test_only_definition_from_general_config():
-    obs = DataStructureDefinition(
-        TEST_DATA_DIR / "general-config-only" / "definitions",
-        dimensions=["region", "variable"],
-    )
-    try:
+        if not external_only:
+            assert "Region A" in obs.region
         # imported from https://github.com/IAMconsortium/common-definitions repo
         assert "World" in obs.region
         # added via general-config definitions


### PR DESCRIPTION
Closes #286. 

I slightly modified the check if the definitions folder is present. 
Now it is called after reading the general config and only fails if there is no definitions folder **and** no external repos.