### PR TITLE
Add `VariableCodeList.units` attribute and tests

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -456,6 +456,8 @@ class VariableCodeList(CodeList):
         """Get the list of all units"""
         units = set()
 
+        # replace "dimensionless" variables (unit: `None`) with empty string
+        # for consistency with the yaml file format
         def to_dimensionless(u):
             return u or ""
 

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -18,6 +18,7 @@ from nomenclature.error.variable import (
     VariableRenameArgError,
     VariableRenameTargetError,
 )
+from pyam.utils import is_list_like
 
 here = Path(__file__).parent.absolute()
 
@@ -449,6 +450,19 @@ class VariableCodeList(CodeList):
     # class variables
     code_basis: ClassVar = VariableCode
     validation_schema: ClassVar[str] = "variable"
+
+    @property
+    def units(self):
+        """Get the list of all units"""
+        unit_set = set()
+        for variable in self.mapping.values():
+            if is_list_like(variable.unit):
+                for u in variable.unit:
+                    unit_set.add(u)
+            else:
+                unit_set.add(variable.unit)
+
+        return list(unit_set)
 
     @validator("mapping")
     def check_variable_region_aggregation_args(cls, v):

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -454,15 +454,18 @@ class VariableCodeList(CodeList):
     @property
     def units(self):
         """Get the list of all units"""
-        unit_set = set()
+        units = set()
+
+        def to_dimensionless(u):
+            return u or ""
+
         for variable in self.mapping.values():
             if is_list_like(variable.unit):
-                for u in variable.unit:
-                    unit_set.add(u)
+                units.update([to_dimensionless(u) for u in variable.unit])
             else:
-                unit_set.add(variable.unit)
+                units.add(to_dimensionless(variable.unit))
 
-        return list(unit_set)
+        return sorted(list(units))
 
     @validator("mapping")
     def check_variable_region_aggregation_args(cls, v):

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -160,8 +160,7 @@ def test_variable_codelist_units():
     codelist = VariableCodeList.from_directory(
         "variable", TEST_DATA_DIR / "validation_nc" / "variable"
     )
-    assert "EJ/yr" in codelist.units
-    assert None in codelist.units
+    assert codelist.units == ["", "EJ/yr"]
 
 
 def test_variable_codelist_multiple_units():
@@ -170,7 +169,7 @@ def test_variable_codelist_multiple_units():
         "variable", TEST_DATA_DIR / "multiple_unit_codelist"
     )
     assert codelist["Var1"].unit == ["unit1", "unit2"]
-    assert sorted(codelist.units) == ["unit1", "unit2"]
+    assert codelist.units == ["unit1", "unit2"]
 
 
 def test_to_excel_read_excel_roundtrip(tmpdir):

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -17,13 +17,13 @@ from conftest import TEST_DATA_DIR
 
 def test_simple_codelist():
     """Import a simple codelist"""
-    code = VariableCodeList.from_directory(
+    codelist = VariableCodeList.from_directory(
         "variable", TEST_DATA_DIR / "simple_codelist"
     )
 
-    assert "Some Variable" in code
-    assert code["Some Variable"].unit is None  # this is a dimensionless variable
-    assert type(code["Some Variable"].bool) == bool  # this is a boolean
+    assert "Some Variable" in codelist
+    assert codelist["Some Variable"].unit is None  # this is a dimensionless variable
+    assert type(codelist["Some Variable"].bool) == bool  # this is a boolean
 
 
 def test_codelist_to_yaml():
@@ -155,12 +155,22 @@ def test_end_whitespace_fails():
         )
 
 
+def test_variable_codelist_units():
+    """Check that the units-attribute works as expected"""
+    codelist = VariableCodeList.from_directory(
+        "variable", TEST_DATA_DIR / "validation_nc" / "variable"
+    )
+    assert "EJ/yr" in codelist.units
+    assert None in codelist.units
+
+
 def test_variable_codelist_multiple_units():
     """Check that multiple units work in a VariableCodeList"""
     codelist = VariableCodeList.from_directory(
         "variable", TEST_DATA_DIR / "multiple_unit_codelist"
     )
     assert codelist["Var1"].unit == ["unit1", "unit2"]
+    assert sorted(codelist.units) == ["unit1", "unit2"]
 
 
 def test_to_excel_read_excel_roundtrip(tmpdir):


### PR DESCRIPTION
I just ran into a situation where I wanted to get all units from a VariableCodeList, so this PR adds an attribute for that...

**Open question**: going back and forth between set and list seems to make the order arbitrary, but allowing "None" (for dimensionless variables) also preempts ordering easily. One could simply drop "None" from that list (given that it's *not* a unit) or we could always add it at the end or replace by "dimensionless" (this is what **pint** does)...