### PR TITLE
Bring cli back

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ sphinx = "^7.2.6"
 sphinx-click = "^5.1.0"
 numpydoc = "^1.6.0"
 
+[tool.poetry.scripts]
+nomenclature = 'nomenclature.cli:cli'
 
 [tool.poetry-dynamic-versioning]
 bump = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from click.testing import CliRunner
 from nomenclature import cli
 from nomenclature.testing import assert_valid_yaml, assert_valid_structure
@@ -7,6 +9,24 @@ import pydantic
 from conftest import TEST_DATA_DIR
 
 runner = CliRunner()
+
+
+def test_cli_is_installed():
+    result = subprocess.run(
+        "poetry run nomenclature",
+        capture_output=True,
+        text=True,
+        shell=True,
+        check=True,
+    )
+    assert all(
+        command in result.stdout
+        for command in (
+            "check-region-aggregation",
+            "validate-project",
+            "validate-yaml",
+        )
+    )
 
 
 def test_cli_valid_yaml_path():


### PR DESCRIPTION
Closes #299.

This PR brings back the cli which was accidentally dropped in v0.13.0. 
It also adds an explicit test to see if the command `nomenclature` is recognized by the system after install. 
Previously we'd only been using the test runner from click which seemingly also works if the cli is not actually installed. This is why this error was not caught.