### PR TITLE
Fix pydantic warnings

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -766,8 +766,13 @@ def _compare_and_merge(
     difference = compare[
         ~np.isclose(compare["original"], compare["aggregated"], rtol=rtol)
     ]
-    difference["difference (%)"] = 100 * np.abs(
-        (difference["original"] - difference["aggregated"]) / difference["original"]
+    difference.insert(
+        len(difference.columns),
+        "difference (%)",
+        100
+        * np.abs(
+            (difference["original"] - difference["aggregated"]) / difference["original"]
+        ),
     )
     difference = difference.sort_values("difference (%)", ascending=False)
     if difference is not None and len(difference):

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -42,7 +42,7 @@ def test_mapping():
         ],
         "exclude_regions": None,
     }
-    assert obs.dict() == exp
+    assert obs.model_dump() == exp
 
 
 @pytest.mark.parametrize(
@@ -136,7 +136,7 @@ def test_region_processor_working(region_processor_path, simple_definition):
     exp_dict = {value["model"][0]: value for value in exp_data}
 
     assert exp_models == set(obs.mappings.keys())
-    assert all(exp_dict[m] == obs.mappings[m].dict() for m in exp_models)
+    assert all(exp_dict[m] == obs.mappings[m].model_dump() for m in exp_models)
 
 
 def test_region_processor_not_defined(simple_definition):


### PR DESCRIPTION
Closes #307.
This PR addresses all the warnings associated with nomenclature itself.
The remaining warnings are pyam and iam-units related.