### PR TITLE
Allow nomenclatureconfig to have region country only

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -1,4 +1,3 @@
-from contextlib import suppress
 import logging
 from pathlib import Path
 from typing import ClassVar, Dict, List
@@ -6,15 +5,14 @@ from typing import ClassVar, Dict, List
 import numpy as np
 import pandas as pd
 import yaml
-from pyam.utils import write_sheet
-from pydantic import field_validator, BaseModel, ValidationInfo
+from pyam.utils import is_list_like, write_sheet
+from pydantic import BaseModel, ValidationInfo, field_validator
 from pydantic_core import PydanticCustomError
 
 import nomenclature
 from nomenclature.code import Code, MetaCode, RegionCode, VariableCode
-from nomenclature.config import NomenclatureConfig
-from nomenclature.error import custom_pydantic_errors, ErrorCollector
-from pyam.utils import is_list_like
+from nomenclature.config import CodeListConfig, NomenclatureConfig
+from nomenclature.error import ErrorCollector, custom_pydantic_errors
 
 here = Path(__file__).parent.absolute()
 

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -44,9 +44,11 @@ class DataStructureDefinition:
         if (file := path.parent / "nomenclature.yaml").exists():
             self.config = NomenclatureConfig.from_file(file=file)
         else:
-            self.config = None
+            self.config = NomenclatureConfig()
 
-        if not path.is_dir() and (self.config is None or not self.config.repositories):
+        if not path.is_dir() and not (
+            self.config.repositories or self.config.definitions.region.country
+        ):
             raise NotADirectoryError(f"Definitions directory not found: {path}")
 
         self.dimensions = dimensions or ["region", "variable"]

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -483,15 +483,14 @@ class RegionProcessor(Processor):
 
         mapping_files = [f for f in path.glob("**/*") if f.suffix in {".yaml", ".yml"}]
 
-        if dsd.config and dsd.config.mappings:
-            for repository in dsd.config.mappings.repositories:
-                mapping_files.extend(
-                    f
-                    for f in (
-                        dsd.config.repositories[repository].local_path / "mappings"
-                    ).glob("**/*")
-                    if f.suffix in {".yaml", ".yml"}
-                )
+        for repository in dsd.config.mappings.repositories:
+            mapping_files.extend(
+                f
+                for f in (
+                    dsd.config.repositories[repository].local_path / "mappings"
+                ).glob("**/*")
+                if f.suffix in {".yaml", ".yml"}
+            )
 
         for file in mapping_files:
             try:

--- a/tests/data/general-config-only-country/nomenclature.yaml
+++ b/tests/data/general-config-only-country/nomenclature.yaml
@@ -1,0 +1,3 @@
+definitions:
+  region:
+    country: true

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -64,6 +64,14 @@ def test_definition_from_general_config(workflow_folder):
         clean_up_external_repos(obs.config.repositories)
 
 
+def test_definition_general_config_country_only():
+    obs = DataStructureDefinition(
+        TEST_DATA_DIR / "general-config-only-country" / "definitions",
+        dimensions=["region"],
+    )
+    assert all(region in obs.region for region in ("Austria", "Bolivia", "Kosovo"))
+
+
 def test_to_excel(simple_definition, tmpdir):
     """Check writing a DataStructureDefinition to file"""
     file = tmpdir / "testing_export.xlsx"


### PR DESCRIPTION
Closes #319.

I took this issues as an opportunity to substitute all the `None` values in `NomenclatureConfig` for empty instances of e.g. `CodeListConfig`.
The advantage of the is that you no longer need to check if a attribute exists in `NomenClatureConfig` but instead you can just iterate over it.