### PR TITLE
Change dimension parameter to singular in cli

### DIFF
--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -36,7 +36,8 @@ def cli_valid_yaml(path: Path):
     default=None,
 )
 @click.option(
-    "--dimensions",
+    "--dimension",
+    "dimensions",
     help="Optional list of dimensions",
     type=str,
     multiple=True,
@@ -68,7 +69,10 @@ def cli_valid_project(
     -------
     $ nomenclature validate-project .
                         --definitions <def-folder> --mappings <map-folder>
-                        --dimensions "['<folder1>', '<folder2>', '<folder3>']"
+                        --dimension <folder1>
+                        --dimension <folder2>
+                        --dimension <folder3>
+
 
 
     Note

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,11 +158,11 @@ def test_cli_custom_dimensions_runs():
         [
             "validate-project",
             str(TEST_DATA_DIR / "non-default_dimensions"),
-            "--dimensions",
+            "--dimension",
             "variable",
-            "--dimensions",
+            "--dimension",
             "region",
-            "--dimensions",
+            "--dimension",
             "scenario",
         ],
     )
@@ -178,7 +178,7 @@ def test_cli_custom_dimensions_fails():
         [
             "validate-project",
             str(TEST_DATA_DIR / "non-default_dimensions"),
-            "--dimensions",
+            "--dimension",
             "foo",
         ],
     )
@@ -196,9 +196,9 @@ def test_cli_empty_dimensions_run():
         [
             "validate-project",
             str(TEST_DATA_DIR / "non-default_dimensions_one_empty"),
-            "--dimensions",
+            "--dimension",
             "variable",
-            "--dimensions",
+            "--dimension",
             "region",
         ],
     )


### PR DESCRIPTION
After seeing openENTRANCE/openentrance#326, I thought it might make for a more logical cli, if changed the `dimensions` parameter to singular, so instead of:

```console
nomenclature validate-project . --dimensions region --dimensions variable
```

we now have:

```console
nomenclature validate-project . --dimension region --dimension variable
```

@danielhuppmann feel free to dismiss this one, just cost me two minutes and I figured it might improve readability of the command.