### PR TITLE
Disallow external repo double stacking

### DIFF
--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -92,8 +92,8 @@ class Repository(BaseModel):
             if config.get("repositories"):
                 raise ValueError(
                     (
-                        "No external repos allowed in external repo, found in "
-                        f"nomenclature.yaml in '{self.url}'"
+                        "External repos cannot again refer to external repos, "
+                        f"found in nomenclature.yaml in '{self.url}'"
                     )
                 )
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -93,7 +93,7 @@ class Repository(BaseModel):
                 raise ValueError(
                     (
                         "No external repos allowed in external repo, found in "
-                        f"nomenclature.yaml in {self.url}"
+                        f"nomenclature.yaml in '{self.url}'"
                     )
                 )
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -82,6 +82,20 @@ class Repository(BaseModel):
         repo.git.clean("-xdf")
         if self.revision == "main":
             repo.remotes.origin.pull()
+        self.check_external_repo_double_stacking()
+
+    def check_external_repo_double_stacking(self):
+        nomenclature_config = self.local_path / "nomenclature.yaml"
+        if nomenclature_config.is_file():
+            with open(nomenclature_config, "r") as f:
+                config = yaml.safe_load(f)
+            if config.get("repositories"):
+                raise ValueError(
+                    (
+                        "No external repos allowed in external repo, found in "
+                        f"nomenclature.yaml in {self.url}"
+                    )
+                )
 
 
 class DataStructureConfig(BaseModel):

--- a/tests/data/double_stacked_external_repo/nomenclature.yaml
+++ b/tests/data/double_stacked_external_repo/nomenclature.yaml
@@ -1,0 +1,6 @@
+repositories:
+  common-definitions:
+    url: https://github.com/IAMconsortium/common-definitions.git/
+definitions:
+  region:
+    repository: common-definitions

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,3 +55,15 @@ def test_multiple_mapping_repos():
         assert nomenclature_config.repositories.keys() == exp_repos
     finally:
         clean_up_external_repos(nomenclature_config.repositories)
+
+
+def test_double_stacked_external_repo_raises(monkeypatch):
+    repo = Repository(url="lorem ipsum")
+    monkeypatch.setitem(
+        repo.__dict__,
+        "local_path",
+        TEST_DATA_DIR / "double_stacked_external_repo",
+    )
+    match = "No external repos allowed in external repo"
+    with raises(ValueError, match=match):
+        repo.check_external_repo_double_stacking()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,6 @@ def test_double_stacked_external_repo_raises(monkeypatch):
         "local_path",
         TEST_DATA_DIR / "double_stacked_external_repo",
     )
-    match = "No external repos allowed in external repo"
+    match = "External repos cannot again refer to external repos"
     with raises(ValueError, match=match):
         repo.check_external_repo_double_stacking()


### PR DESCRIPTION
Closes #316.
 
This PR implements a check that an external repo does not reference another external repo, thus safeguarding against external repo double stacking.