### PR TITLE
Do not show full error message for missing weights

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -735,9 +735,7 @@ def _aggregate_region(df, var, *regions, **kwargs):
     except ValueError as error:
         if str(error).startswith("Missing weights for the following data"):
             logger.info(
-                (
-                    f"Could not aggregate '{var}' for region '{regions[0]}' ({kwargs})"
-                )
+                f"Could not aggregate '{var}' for region '{regions[0]}' ({kwargs})"
             )
         else:
             raise error

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -736,8 +736,7 @@ def _aggregate_region(df, var, *regions, **kwargs):
         if str(error).startswith("Missing weights for the following data"):
             logger.info(
                 (
-                    f"Could not aggregate '{var}' for region '{regions[0]}' "
-                    f"({kwargs})\n{error}"
+                    f"Could not aggregate '{var}' for region '{regions[0]}' ({kwargs})"
                 )
             )
         else:


### PR DESCRIPTION
While working on the ECEMF-workflow migration, I realized that showing the full log message from the "missing-weights" error from pyam was really too much in the nomenclature output...