### PR TITLE
Use correct virtual environment for building the docs on ReadTheDocs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,30 +13,35 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    #----------------------------------------------
-    #  -----  install & configure poetry  -----
-    #----------------------------------------------
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-        installer-parallel: true
-    - name: Install poetry dynamic versioning plugin
-      run: poetry self add "poetry-dynamic-versioning[plugin]"
-    - name: Install Pandoc
-      uses: r-lib/actions/setup-pandoc@v1
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-    - name: Install dependencies and package for building the docs
-      run: poetry install --no-interaction --with docs
+      - name: Install Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
 
-    - name: Build the docs
-      run: |
-          source .venv/bin/activate
-          make --directory=docs html
+      #------------------------------
+      #  install & configure poetry
+      #------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Install poetry dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
+
+      #-------------------------------------------
+      #  install root project and build the docs
+      #-------------------------------------------
+      - name: Install library
+        run: poetry install --no-interaction --with docs
+
+      - name: Build the docs
+        run: poetry run make --directory=docs html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,19 +3,20 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
   jobs:
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+      - poetry self add "poetry-dynamic-versioning[plugin]"
     post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry self add "poetry-dynamic-versioning[plugin]"
-      - poetry install --with docs
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 sphinx:
+  builder: html
   configuration: docs/conf.py


### PR DESCRIPTION
Seems that since poetry 1.8, there is an issue that the new poetry installs to the wrong virtual environment, see https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry.

This PR mirrors https://github.com/IAMconsortium/pyam/pull/836

FYI @phackstock 