### PR TITLE
Improve duplicate code output

### DIFF
--- a/tests/data/duplicate-code-list/variable/duplicate_entries.yaml
+++ b/tests/data/duplicate-code-list/variable/duplicate_entries.yaml
@@ -6,7 +6,7 @@
     unit:
 - Some other Variable:
     description:
-    unit:
+    unit: a
 - Some other Variable:
     description:
-    unit:
+    unit: b

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -67,7 +67,7 @@ def test_codelist_to_yaml():
 
 def test_duplicate_code_raises():
     """Check that code conflicts across different files raises"""
-    match = "Duplicate item in variable codelist: Some Variable"
+    match = "Conflicting duplicate items in 'variable' codelist: 'Some Variable'"
     with raises(ValueError, match=match):
         VariableCodeList.from_directory(
             "variable", TEST_DATA_DIR / "duplicate_code_raises"
@@ -369,7 +369,10 @@ def test_multiple_external_repos():
 
 @pytest.mark.parametrize("CodeList", [VariableCodeList, CodeList])
 def test_variable_codelist_with_duplicates_raises(CodeList):
-    error_string = "2 errors:\n.*Some Variable\n.*Some other Variable"
+    error_string = (
+        "2 errors:\n.*Identical.*'Some Variable'.*\n.*Conflicting."
+        "*'Some other Variable'"
+    )
     with raises(ValueError, match=error_string):
         CodeList.from_directory(
             "variable", TEST_DATA_DIR / "duplicate-code-list" / "variable"


### PR DESCRIPTION
Closes #337.

This came up when trying to combine variable lists for the IAM and short term models for NGFS.
There were 77 duplicate entries and I had to figure out which ones to keep, remove, rename, etc...

To this end I've updated the output of the error in case we have duplicate CodeList entries.
From:
```console

```

we now have:
```console
  1. Identical duplicate items in 'variable' codelist: 'Some Variable'
  2. Conflicting duplicate items in 'variable' codelist: 'Some other Variable'
    {'file': 'variable/duplicate_entries.yaml', 'extra_attributes': {'unit': 'a'}}
    {'file': 'variable/duplicate_entries.yaml', 'extra_attributes': {'unit': 'b'}}
```

The two key changes are:
1. As the error is raise the two codes are compared. The result of the comparison is included in the error message for quicker debugging.
2. If the codes are not identical, their values are shown so that you can work through the differences faster.