### PR TITLE
Run workflow file directly from cli

### DIFF
--- a/docs/user_guide/local-usage.rst
+++ b/docs/user_guide/local-usage.rst
@@ -68,16 +68,16 @@ A more elaborate use case is to perform validation against the codelists and use
   # Import the necessary libraries
   import pyam
   from nomenclature import DataStructureDefinition, RegionProcessor, process
-  
+
   # Initialize a DataStructureDefinition from a suitable directory
   dsd = DataStructureDefinition("definitions")
-  
+
   # Initialize a RegionProcessor from a suitable directory that has the mappings
   rp = RegionProcessor.from_directory("mappings")
-  
+
   # Read the data using pyam
   df = pyam.IamDataFrame("/path/to/file")
-  
+
   # Perform the validation and apply the region aggregation
   df = process(df, dsd, processor=rp)
 
@@ -92,6 +92,27 @@ implemented as a ``main()`` function in ``workflow.py`` of a project repository.
 
 .. attention:: The working-directory of the Python console has to be set to the clone
      of the project repository.
+
+A project workflow can be run directly form the console using the ``nomenclature
+run-workflow`` command.
+
+.. code-block:: console
+
+  nomenclature run-workflow input_data.xlsx
+
+The output should be saved using the ``--output-file`` option with a path to an excel
+file.
+
+.. code-block:: console
+
+  nomenclature run-workflow input_data.xlsx --output-file output.xlsx
+
+If the current working directory is not the workflow directory and/or the processing function is not main, this is also covered:
+
+.. code-block:: console
+
+  nomenclature run-workflow input_data.xlsx --workflow-file path/to/workflow.py --workflow-function not_main --output-file output.xlsx
+
 
 .. code-block:: python
 

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -263,8 +263,6 @@ def cli_run_workflow(
     if not hasattr(workflow, workflow_function):
         raise ValueError(f"{workflow} does not have a function `{workflow_function}`")
 
+    df = getattr(workflow, workflow_function)(IamDataFrame(input_file))
     if output_file is not None:
-        getattr(workflow, workflow_function)(IamDataFrame(input_file)).to_excel(
-            output_file
-        )
-    getattr(workflow, workflow_function)(IamDataFrame(input_file))
+        df.to_excel(output_file)

--- a/tests/data/workflow/workflow.py
+++ b/tests/data/workflow/workflow.py
@@ -1,0 +1,2 @@
+def main(df):
+    return df

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,13 +6,15 @@ import pydantic
 import pytest
 
 from click.testing import CliRunner
-from conftest import TEST_DATA_DIR
 from pandas.testing import assert_frame_equal
 from pyam import IAMC_IDX, IamDataFrame, assert_iamframe_equal
 
 from nomenclature import cli
 from nomenclature.testing import assert_valid_structure, assert_valid_yaml
 from nomenclature.codelist import VariableCodeList
+from nomenclature.cli import cli_run_workflow
+
+from conftest import TEST_DATA_DIR
 
 runner = CliRunner()
 
@@ -360,3 +362,22 @@ def test_cli_add_missing_variables(simple_definition, tmp_path):
 
     assert "Some new variable" in obs
     assert obs["Some new variable"].unit == "EJ/yr"
+
+
+def test_cli_run_workflow(tmp_path, simple_df):
+
+    simple_df.to_excel(tmp_path / "input.xlsx")
+
+    runner.invoke(
+        cli,
+        [
+            "run-workflow",
+            str(tmp_path / "input.xlsx"),
+            "--workflow-file",
+            str(TEST_DATA_DIR / "workflow" / "workflow.py"),
+            "--output-file",
+            str(tmp_path / "output.xlsx"),
+        ],
+    )
+
+    assert_iamframe_equal(simple_df, IamDataFrame(tmp_path / "output.xlsx"))


### PR DESCRIPTION
Closes #351.

This PR adds a CLI option to directly run a processing function (in most cases `main`) from the command line:

```console
nomenclature run-workflow input_data.xlsx --output-file output.xlsx
```
to reproduce the processing and find out what might be going on. 

Using `--output-file` is optional since we're not always interested in the output of the processing.
If the current working directory is not the workflow directory and/or the processing function is not `main`, this is also covered:

```console
nomenclature run-workflow input_data.xlsx --workflow-file path/to/workflow.py --workflow-function not_main --output-file output.xlsx
```