### PR TITLE
Improve missing data output

### DIFF
--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -178,7 +178,13 @@ class RequiredDataValidator(Processor):
             for model, data_list in missing_data.items():
                 missing_data_log_info += f"Missing for '{model}':\n"
                 for data in data_list:
-                    missing_data_log_info += f"{data}\n\n"
+                    missing_data_log_info += (
+                        data.to_string(
+                            index=False,
+                            justify="left",
+                        )
+                        + "\n\n"
+                    )
             logger.error(
                 "Missing required data.\nFile: %s\n\n%s",
                 get_relative_path(self.file),

--- a/nomenclature/processor/required_data.py
+++ b/nomenclature/processor/required_data.py
@@ -218,6 +218,7 @@ class RequiredDataValidator(Processor):
                         .to_frame()
                         .reset_index()
                         .drop(columns=["model"])
+                        .rename(columns={"year": "year(s)"})
                     )
         return missing_data
 

--- a/tests/data/required_data/required_data/requiredData_apply_error.yaml
+++ b/tests/data/required_data/required_data/requiredData_apply_error.yaml
@@ -1,7 +1,7 @@
 model: model_a
 required_data:
   - measurand:
-    - Primary Energy:
+    - Primary Energy|Making sure that a really long variable is displayed completely:
         unit: [GWh/yr, Mtoe]
     year: [2005, 2010, 2015] # 2015 is missing from simple_df for all models
   - variable: Final Energy

--- a/tests/test_required_data.py
+++ b/tests/test_required_data.py
@@ -100,24 +100,20 @@ def test_RequiredData_apply_raises(simple_df, caplog):
         required_data_validator.apply(simple_df)
 
     missing_data = [
-        """
-  scenario        variable    unit            year
-0   scen_a  Primary Energy  GWh/yr  2005,2010,2015
-1   scen_a  Primary Energy    Mtoe  2005,2010,2015
-2   scen_b  Primary Energy  GWh/yr  2005,2010,2015
-3   scen_b  Primary Energy    Mtoe  2005,2010,2015""",
-        """
-  scenario      variable
-0   scen_a  Final Energy
-1   scen_b  Final Energy""",
-        """
-  scenario       variable       unit
-0   scen_a  Emissions|CO2  Mt CO2/yr
-1   scen_b  Emissions|CO2  Mt CO2/yr""",
-        """
-  scenario region      variable
-0   scen_a  World  Final Energy
-1   scen_b  World  Final Energy""",
+        """scenario variable                                                                       unit   year(s)""",
+        """scen_a   Primary Energy|Making sure that a really long variable is displayed completely GWh/yr 2005,2010,2015
+scen_a   Primary Energy|Making sure that a really long variable is displayed completely   Mtoe 2005,2010,2015
+scen_b   Primary Energy|Making sure that a really long variable is displayed completely GWh/yr 2005,2010,2015
+scen_b   Primary Energy|Making sure that a really long variable is displayed completely   Mtoe 2005,2010,2015""",
+        """scenario variable""",
+        """scen_a   Final Energy
+scen_b   Final Energy""",
+        """scenario variable      unit""",
+        """scen_a   Emissions|CO2 Mt CO2/yr
+scen_b   Emissions|CO2 Mt CO2/yr""",
+        """scenario region variable""",
+        """scen_a   World  Final Energy
+scen_b   World  Final Energy""",
     ]
     # check if the log message contains the correct information
     assert all(


### PR DESCRIPTION
Closes #258.
This PR makes three improvements to the output of `RequiredDataValidator`:

1. The output no longer gets shortened so that the user can actually see what is missing
2. The output no longer writes out the numeric pandas index making it slightly more compact
3. The output is now left justified further making it more compact

In concrete terms, instead of:

```console
  scenario  ...         year(s)
0   scen_a  ...  2005,2010,2015
1   scen_a  ...  2005,2010,2015
2   scen_b  ...  2005,2010,2015
3   scen_b  ...  2005,2010,2015

[4 rows x 4 columns]
```

we now get:

```console
scenario variable                                                                       unit   year(s)
scen_a   Primary Energy|Making sure that a really long variable is displayed completely GWh/yr 2005,2010,2015
scen_a   Primary Energy|Making sure that a really long variable is displayed completely   Mtoe 2005,2010,2015
scen_b   Primary Energy|Making sure that a really long variable is displayed completely GWh/yr 2005,2010,2015
scen_b   Primary Energy|Making sure that a really long variable is displayed completely   Mtoe 2005,2010,2015
``` 

which means that a user can now get actually useful information.