### PR TITLE
Read dimensions other than `variable` and `region` from external repo

### DIFF
--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -122,12 +122,12 @@ class DataStructureConfig(BaseModel):
 
     """
 
-    region: Optional[RegionCodeListConfig] = Field(default_factory=RegionCodeListConfig)
-    variable: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
     model: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
     scenario: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
+    region: Optional[RegionCodeListConfig] = Field(default_factory=RegionCodeListConfig)
+    variable: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
 
-    @field_validator("region", "variable", "model", "scenario", mode="before")
+    @field_validator("model", "scenario", "region", "variable", mode="before")
     @classmethod
     def add_dimension(cls, v, info: ValidationInfo):
         return {"dimension": info.field_name, **v}
@@ -136,7 +136,7 @@ class DataStructureConfig(BaseModel):
     def repos(self) -> dict[str, str]:
         return {
             dimension: getattr(self, dimension).repositories
-            for dimension in ("region", "variable", "model", "scenario")
+            for dimension in ("model", "scenario", "region", "variable")
             if getattr(self, dimension).repositories
         }
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -127,7 +127,7 @@ class DataStructureConfig(BaseModel):
     model: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
     scenario: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
 
-    @field_validator("region", "variable", mode="before")
+    @field_validator("region", "variable", "model", "scenario", mode="before")
     @classmethod
     def add_dimension(cls, v, info: ValidationInfo):
         return {"dimension": info.field_name, **v}
@@ -136,7 +136,7 @@ class DataStructureConfig(BaseModel):
     def repos(self) -> dict[str, str]:
         return {
             dimension: getattr(self, dimension).repositories
-            for dimension in ("region", "variable")
+            for dimension in ("region", "variable", "model", "scenario")
             if getattr(self, dimension).repositories
         }
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -124,6 +124,8 @@ class DataStructureConfig(BaseModel):
 
     region: Optional[RegionCodeListConfig] = Field(default_factory=RegionCodeListConfig)
     variable: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
+    model: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
+    scenario: Optional[CodeListConfig] = Field(default_factory=CodeListConfig)
 
     @field_validator("region", "variable", mode="before")
     @classmethod


### PR DESCRIPTION
This PR fixes #414, as far as I can see. All tests pass, the error cited in #414 goes away, and the resulting `DataStructureDefinition` object has the expected dimensions.

If possible, it would be great if this PR could be merged as soon as possible, since it's a bug that can cause significant problems. Some possible items that might be considered in the future (none of which I have the capacity to work on in the next few months):

* Add a test. A proper test for this issue would probably be an integration test, which tries to read from a test repo that has all the valid dimensions and a non-empty codelist for each them, and checks that the resulting `DataStructureDefinition` object has all the expected dimensions and the expected codes in each codelist. As far as I can see, there is no such test currently?
* This PR still hardcodes the dimensions to be in `{'region', 'variable', 'model', 'scenario'}`. The question is whether other arbitrary dimensions should be allowed. But at the moment, I think that would cause issues multiple other places in the code, so probably goes far beyond the scope of this PR.