### PR TITLE
Remove `dimensions` implicit default from `DataStructureDefinition`

### DIFF
--- a/docs/user_guide/config.rst
+++ b/docs/user_guide/config.rst
@@ -103,7 +103,9 @@ Specify dimensions to be read
 -----------------------------
 
 The configuration file offers the possibility to set the dimensions which will be read
-by *DataStructureDefinition*.
+by *DataStructureDefinition*, overriding the dimensions from the *definitions*
+sub-directories. If no sub-directories exist (e.g.: when importing dimensions
+from external repositories), setting dimensions in the configuration file is mandatory.
 
 In the below case we specify *region*, *variable* and *scenario* to be read and used for
 validation:

--- a/docs/user_guide/directory-structure.rst
+++ b/docs/user_guide/directory-structure.rst
@@ -25,9 +25,9 @@ This is the directory structure for validation and region processing:
 
 The :class:`DataStructureDefinition` reads the codelists from the *definitions* folder.
 
-* Each "dimension" to be used for validation (default: *variable* and *region*) must
-  have its own sub-directory in the *definitions* folder. The dimension names usually
-  follow the column names of the IAMC data format.
+* Each "dimension" to be used for validation must have its own sub-directory in
+  the *definitions* folder. The dimension names usually follow the column names
+  of the IAMC data format.
 
 * The codelists for a dimension can be distributed across multiple yaml files within a
   dimension folder, including any subfolders. When the :class:`DataStructureDefinition`

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -69,7 +69,7 @@ class DataStructureDefinition:
             or [x.stem for x in path.iterdir() if x.is_dir()]
         )
         if not self.dimensions:
-            raise ValueError("No dimensions specified in data structure.")
+            raise ValueError("No dimensions specified.")
 
         for dim in self.dimensions:
             codelist_cls = SPECIAL_CODELIST.get(dim, CodeList)

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -66,11 +66,11 @@ class DataStructureDefinition:
         self.dimensions = (
             dimensions
             or self.config.dimensions
-            or [
-                "region",
-                "variable",
-            ]
+            or [x.stem for x in path.iterdir() if x.is_dir()]
         )
+        if not self.dimensions:
+            raise ValueError("No dimensions specified in data structure.")
+
         for dim in self.dimensions:
             codelist_cls = SPECIAL_CODELIST.get(dim, CodeList)
             self.__setattr__(

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import yaml
 
 from nomenclature.definition import DataStructureDefinition
+from nomenclature.config import NomenclatureConfig
 from nomenclature.processor import (
     DataValidator,
     RegionProcessor,
@@ -144,8 +145,12 @@ def assert_valid_structure(
             f"Definitions directory not found: {path / definitions}"
         )
 
-    if dimensions == ():  # if "dimensions" were not specified
-        dimensions = [x.stem for x in (path / definitions).iterdir() if x.is_dir()]
+    if not dimensions:  # if "dimensions" were not specified
+        dimensions = (
+            NomenclatureConfig.from_file(path / "nomenclature.yaml").dimensions
+            if (path / "nomenclature.yaml").is_file()
+            else [x.stem for x in (path / definitions).iterdir() if x.is_dir()]
+        )
         if not dimensions:
             raise FileNotFoundError(
                 f"`definitions` directory is empty: {path / definitions}"

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 import yaml
 
 from nomenclature.definition import DataStructureDefinition
-from nomenclature.config import NomenclatureConfig
 from nomenclature.processor import (
     DataValidator,
     RegionProcessor,
@@ -55,11 +54,9 @@ def assert_valid_yaml(path: Path):
 
 def _check_mappings(
     path: Path,
-    definitions: str = "definitions",
-    dimensions: Optional[List[str]] = None,
+    dsd: DataStructureDefinition,
     mappings: Optional[str] = None,
 ) -> None:
-    dsd = DataStructureDefinition(path / definitions, dimensions)
     if mappings is None:
         if (path / "mappings").is_dir():
             RegionProcessor.from_directory(path / "mappings", dsd)
@@ -86,13 +83,11 @@ def _collect_processor_errors(
 
 def _check_processor_directory(
     path: Path,
+    dsd: DataStructureDefinition,
     processor: Processor,
     processor_arg: str,
     folder: Optional[str] = None,
-    definitions: Optional[str] = "definitions",
-    dimensions: Optional[List[str]] = None,
 ) -> None:
-    dsd = DataStructureDefinition(path / definitions, dimensions)
     if folder is None:
         if (path / processor_arg).is_dir():
             _collect_processor_errors(path / processor_arg, processor, dsd)
@@ -145,28 +140,12 @@ def assert_valid_structure(
             f"Definitions directory not found: {path / definitions}"
         )
 
-    if not dimensions:  # if "dimensions" were not specified
-        dimensions = (
-            NomenclatureConfig.from_file(path / "nomenclature.yaml").dimensions
-            if (path / "nomenclature.yaml").is_file()
-            else [x.stem for x in (path / definitions).iterdir() if x.is_dir()]
-        )
-        if not dimensions:
-            raise FileNotFoundError(
-                f"`definitions` directory is empty: {path / definitions}"
-            )
-    _check_mappings(path, definitions, dimensions, mappings)
+    dsd = DataStructureDefinition(path / definitions, dimensions)
+    _check_mappings(path, dsd, mappings)
     _check_processor_directory(
-        path,
-        RequiredDataValidator,
-        "required_data",
-        required_data,
-        definitions,
-        dimensions,
+        path, dsd, RequiredDataValidator, "required_data", required_data
     )
-    _check_processor_directory(
-        path, DataValidator, "validate_data", validate_data, definitions, dimensions
-    )
+    _check_processor_directory(path, dsd, DataValidator, "validate_data", validate_data)
 
 
 # Todo: add function which runs `DataStructureDefinition(path).validate(scenario)`

--- a/tests/data/region_processing/external_repo_test/nomenclature.yaml
+++ b/tests/data/region_processing/external_repo_test/nomenclature.yaml
@@ -1,3 +1,6 @@
+dimensions:
+  - region
+  - variable
 repositories:
   common-definitions:
     url: https://github.com/IAMconsortium/common-definitions.git/

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,7 +306,7 @@ def test_cli_empty_definitions_dir():
 
     assert cli_result.exit_code == 1
     assert isinstance(cli_result.exception, ValueError)
-    assert "No dimensions specified in data structure." in str(cli_result.exception)
+    assert "No dimensions specified." in str(cli_result.exception)
 
 
 def test_check_region_aggregation(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,8 +305,8 @@ def test_cli_empty_definitions_dir():
     )
 
     assert cli_result.exit_code == 1
-    assert isinstance(cli_result.exception, FileNotFoundError)
-    assert "`definitions` directory is empty" in str(cli_result.exception)
+    assert isinstance(cli_result.exception, ValueError)
+    assert "No dimensions specified in data structure." in str(cli_result.exception)
 
 
 def test_check_region_aggregation(tmp_path):

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -34,7 +34,7 @@ def test_nonexisting_path_raises():
 
 def test_empty_codelist_raises():
     """Check that initializing a DataStructureDefinition with empty CodeList raises"""
-    match = "No dimensions specified in data structure."
+    match = "No dimensions specified."
     with pytest.raises(ValueError, match=match):
         DataStructureDefinition(TEST_DATA_DIR / "codelist" / "simple_codelist")
 

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -34,7 +34,7 @@ def test_nonexisting_path_raises():
 
 def test_empty_codelist_raises():
     """Check that initializing a DataStructureDefinition with empty CodeList raises"""
-    match = "Empty codelist: region, variable"
+    match = "No dimensions specified in data structure."
     with pytest.raises(ValueError, match=match):
         DataStructureDefinition(TEST_DATA_DIR / "codelist" / "simple_codelist")
 
@@ -134,8 +134,7 @@ def test_create_yaml_from_xlsx(input_file, attrs, exp_file, tmpdir):
 
     with open(file, "r", encoding="utf-8") as f:
         obs = f.read()
-    with open(TEST_DATA_DIR / "io" / "excel_io" / exp_file, "r",
-              encoding="utf-8") as f:
+    with open(TEST_DATA_DIR / "io" / "excel_io" / exp_file, "r", encoding="utf-8") as f:
         exp = f.read()
 
     assert obs == exp


### PR DESCRIPTION
Removes implicit default dimensions `["region", "variable"]` from `DataStructureDefinition`, instead defaulting to `definitions` subdirectories.
Running workflows without `definitions` subdirectories is also possible as long as `nomenclature.yaml` sets the dimensions and respective external repos (see `test_mapping_from_external_repository`'s configuration file).
For project validation, `dimensions` defaults to either those in `nomenclature.yaml` or to `definitions` subdirectories (without either, it fails).