### PR TITLE
Support directional region validation

### DIFF
--- a/docs/user_guide/region.rst
+++ b/docs/user_guide/region.rst
@@ -22,6 +22,20 @@ Regions can have attributes, for example a description or ISO3-codes. If the att
 `iso3_codes` is provided, the item(s) are validated against a list of valid codes taken
 from the `pycountry <https://github.com/flyingcircusio/pycountry>`_ package.
 
+Directional data
+----------------
+
+For reporting of directional data (e.g., trade flows), "directional regions" can be
+defined using a *>* separator. The region before the separator is the *origin*,
+the region after the separator is the *destination*.
+
+.. code:: yaml
+
+   - Trade Connections:
+     - China>Europe
+
+Both the origin and destination regions must be defined in the region codelist.
+
 Common regions
 --------------
 

--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -309,6 +309,22 @@ class RegionCode(Code):
             raise ValueError(errors)
         return v
 
+    @property
+    def is_directional(self) -> bool:
+        return ">" in self.name
+
+    @property
+    def destination(self) -> str:
+        if not self.is_directional:
+            raise ValueError("Non directional region does not have a destination")
+        return self.name.split(">")[1]
+
+    @property
+    def origin(self) -> str:
+        if not self.is_directional:
+            raise ValueError("Non directional region does not have an origin")
+        return self.name.split(">")[0]
+
 
 class MetaCode(Code):
     """Code object with allowed values list

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -788,6 +788,18 @@ class RegionCodeList(CodeList):
                     )
                 )
             mapping[code.name] = code
+
+        for code in list(mapping):
+            if ">" in code:
+                origin, destination = code.split(">")
+                for region in [origin, destination]:
+                    if region not in mapping:
+                        errors.append(
+                            ValueError(
+                                f"Region '{region}' not defined for '{code}'"
+                            )
+                        )
+
         if errors:
             raise ValueError(errors)
         return cls(name=name, mapping=mapping)

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -801,11 +801,11 @@ class RegionCodeList(CodeList):
             if region.is_directional:
                 if region.origin not in v:
                     missing_regions.append(
-                        f"Region '{region.origin}' not defined for '{region.name}'"
+                        f"Origin '{region.origin}' not defined for '{region.name}'"
                     )
                 if region.destination not in v:
                     missing_regions.append(
-                        f"Region '{region.destination}' not defined for '{region.name}'"
+                        f"Destination '{region.destination}' not defined for '{region.name}'"
                     )
         if missing_regions:
             raise ValueError("\n".join(missing_regions))

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -795,9 +795,7 @@ class RegionCodeList(CodeList):
                 for region in [origin, destination]:
                     if region not in mapping:
                         errors.append(
-                            ValueError(
-                                f"Region '{region}' not defined for '{code}'"
-                            )
+                            ValueError(f"Region '{region}' not defined for '{code}'")
                         )
 
         if errors:

--- a/tests/data/codelist/region_codelist/directional_non-existing_component/region.yaml
+++ b/tests/data/codelist/region_codelist/directional_non-existing_component/region.yaml
@@ -1,0 +1,4 @@
+- countries:
+    - Austria
+- directional:
+    - Austria>Germany

--- a/tests/data/codelist/region_codelist/simple/region.yaml
+++ b/tests/data/codelist/region_codelist/simple/region.yaml
@@ -1,7 +1,9 @@
 - common:
-  - World:
-      definition: The entire world
+    - World:
+        definition: The entire world
 - countries:
-  - Some Country:
-      iso2: XY
-      iso3: XYZ
+    - Some Country:
+        iso2: XY
+        iso3: XYZ
+- directional:
+    - Some Country>World

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -394,7 +394,6 @@ def test_RegionCodeList_filter():
 def test_RegionCodeList_hierarchy():
     """Verifies that the hierarchy method returns a list"""
 
-
     rcl = RegionCodeList.from_directory(
         "Region", MODULE_TEST_DATA_DIR / "region_to_filter_codelist"
     )

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -193,6 +193,9 @@ def test_region_codelist():
     assert code["Some Country"].hierarchy == "countries"
     assert code["Some Country"].iso2 == "XY"
 
+    assert "Some Country>World" in code
+    assert code["Some Country>World"].hierarchy == "directional"
+
 
 def test_region_codelist_nonexisting_country_name():
     """Check that countries are validated against `nomenclature.countries`"""
@@ -202,6 +205,17 @@ def test_region_codelist_nonexisting_country_name():
             MODULE_TEST_DATA_DIR
             / "region_codelist"
             / "countries_attribute_non-existing_name",
+        )
+
+
+def test_directional_region_codelist_nonexisting_country_name():
+    """Check that directional regions have defined origin and destination"""
+    with pytest.raises(ValueError, match="Region 'Germany' not .* 'Austria>Germany'"):
+        RegionCodeList.from_directory(
+            "region",
+            MODULE_TEST_DATA_DIR
+            / "region_codelist"
+            / "directional_non-existing_component",
         )
 
 

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -210,7 +210,7 @@ def test_region_codelist_nonexisting_country_name():
 
 def test_directional_region_codelist_nonexisting_country_name():
     """Check that directional regions have defined origin and destination"""
-    with pytest.raises(ValueError, match="Region 'Germany' not .* 'Austria>Germany'"):
+    with pytest.raises(ValueError, match="Destination 'Germany' .* 'Austria>Germany'"):
         RegionCodeList.from_directory(
             "region",
             MODULE_TEST_DATA_DIR

--- a/tests/test_model_registration_parser.py
+++ b/tests/test_model_registration_parser.py
@@ -15,8 +15,7 @@ def test_parse_model_registration(tmp_path):
     )
 
     # Test model mapping
-    with open(tmp_path / "Model 1.1_mapping.yaml", "r", encoding="utf-8") \
-            as file:
+    with open(tmp_path / "Model 1.1_mapping.yaml", "r", encoding="utf-8") as file:
         obs_model_mapping = yaml.safe_load(file)
     with open(
         TEST_DATA_DIR
@@ -30,8 +29,7 @@ def test_parse_model_registration(tmp_path):
     assert obs_model_mapping == exp_model_mapping
 
     # Test model regions
-    with open(tmp_path / "Model 1.1_regions.yaml", "r", encoding="utf-8") \
-            as file:
+    with open(tmp_path / "Model 1.1_regions.yaml", "r", encoding="utf-8") as file:
         obs_model_regions = yaml.safe_load(file)
     exp_model_regions = [
         {"Model 1.1": ["Model 1.1|Region 1", "Region 2", "Model 1.1|Region 3"]}


### PR DESCRIPTION
This PR implements validation for "directional regions" - when defining a region to report e.g. trade flows, this can be implemented as "China>Europe" using a > character. Both the source and the destination have to be defined in the codelist. 