### PR TITLE
Fix wildcard aggregation by skipping

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import (
     field_validator,
     field_serializer,
+    model_validator,
     ConfigDict,
     BaseModel,
     Field,
@@ -207,6 +208,13 @@ class VariableCode(Code):
     @field_validator("unit", mode="before")
     def convert_none_to_empty_string(cls, v):
         return v if v is not None else ""
+
+    @model_validator(mode="after")
+    def wildcard_must_skip_region_aggregation(cls, data):
+        if "*" in data.name and data.skip_region_aggregation is False:
+            raise ValueError(
+                f"Wildcard variable '{data.name}' must skip region aggregation"
+            )
 
     @field_validator("components", mode="before")
     def cast_variable_components_args(cls, v):

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -601,7 +601,9 @@ class VariableCodeList(CodeList):
         return [
             var
             for var in variables
-            if var in self.keys() and not self[var].agg_kwargs and not self[var].skip_region_aggregation
+            if var in self.keys()
+            and not self[var].agg_kwargs
+            and not self[var].skip_region_aggregation
         ]
 
     def vars_kwargs(self, variables: list[str]) -> list[VariableCode]:
@@ -610,7 +612,9 @@ class VariableCodeList(CodeList):
         return [
             self[var]
             for var in variables
-            if var in self.keys() and self[var].agg_kwargs and not self[var].skip_region_aggregation
+            if var in self.keys()
+            and self[var].agg_kwargs
+            and not self[var].skip_region_aggregation
         ]
 
     def validate_units(

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -595,11 +595,11 @@ class VariableCodeList(CodeList):
             )
         return v
 
-    def vars_default_args(self, variables: list[str]) -> list[VariableCode]:
+    def vars_default_args(self, variables: list[str]) -> list[str]:
         """return subset of variables which does not feature any special pyam
         aggregation arguments and where skip_region_aggregation is False"""
         return [
-            self[var]
+            var
             for var in variables
             if not self[var].agg_kwargs and not self[var].skip_region_aggregation
         ]
@@ -621,8 +621,7 @@ class VariableCodeList(CodeList):
         if invalid_units := [
             (variable, unit, self.mapping[variable].unit)
             for variable, unit in unit_mapping.items()
-            if variable in self.variables
-            and unit not in self.mapping[variable].units
+            if variable in self.variables and unit not in self.mapping[variable].units
         ]:
             lst = [
                 f"'{v}' - expected: {'one of ' if isinstance(e, list) else ''}"

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -601,7 +601,7 @@ class VariableCodeList(CodeList):
         return [
             var
             for var in variables
-            if not self[var].agg_kwargs and not self[var].skip_region_aggregation
+            if var in self.keys() and not self[var].agg_kwargs and not self[var].skip_region_aggregation
         ]
 
     def vars_kwargs(self, variables: list[str]) -> list[VariableCode]:
@@ -610,7 +610,7 @@ class VariableCodeList(CodeList):
         return [
             self[var]
             for var in variables
-            if self[var].agg_kwargs and not self[var].skip_region_aggregation
+            if var in self.keys() and self[var].agg_kwargs and not self[var].skip_region_aggregation
         ]
 
     def validate_units(

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -139,6 +139,9 @@ class DataStructureDefinition:
 
         with adjust_log_level(level="WARNING"):
             for code in df.variable:
+                if code not in self.variable.mapping:
+                    continue
+
                 attr = self.variable.mapping[code]
                 if attr.check_aggregate:
                     components = attr.components

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -646,7 +646,7 @@ class RegionProcessor(Processor):
 
                     # first, perform 'simple' aggregation (no arguments)
                     simple_vars = [
-                        var.name
+                        var
                         for var in self.variable_codelist.vars_default_args(
                             model_df.variable
                         )

--- a/tests/data/region_processing/skip_aggregation/mappings/model_a.yaml
+++ b/tests/data/region_processing/skip_aggregation/mappings/model_a.yaml
@@ -1,4 +1,4 @@
-model: m_a
+model: model_a
 native_regions:
   - region_A
   - region_B

--- a/tests/data/region_processing/wildcard_skip_aggregation/dsd/region/regions.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/dsd/region/regions.yaml
@@ -1,0 +1,5 @@
+- common:
+  - World
+- model_native:
+  - region_A
+  - region_B

--- a/tests/data/region_processing/wildcard_skip_aggregation/dsd/variable/variables.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/dsd/variable/variables.yaml
@@ -1,0 +1,4 @@
+- Capital Cost|Electricity|*:
+    definition: Capital cost of electricity generation for a specific technology
+    unit: USD_2010/kW
+    skip-region-aggregation: true

--- a/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_a.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_a.yaml
@@ -1,0 +1,8 @@
+model: m_a
+native_regions:
+  - region_A
+  - region_B
+common_regions:
+  - World:
+    - region_A
+    - region_B

--- a/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_a.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_a.yaml
@@ -2,3 +2,7 @@ model: model_a
 native_regions:
   - region_A
   - region_B
+common_regions:
+  - World:
+    - region_A
+    - region_B

--- a/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_a.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_a.yaml
@@ -1,8 +1,4 @@
-model: m_a
+model: model_a
 native_regions:
   - region_A
   - region_B
-common_regions:
-  - World:
-    - region_A
-    - region_B

--- a/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_b.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_b.yaml
@@ -1,0 +1,6 @@
+model: model_b
+common_regions:
+  - region_A:
+    - region_A
+  - region_B:
+    - region_b

--- a/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_b.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_b.yaml
@@ -1,6 +1,4 @@
 model: model_b
-common_regions:
-  - region_A:
-    - region_A
-  - region_B:
-    - region_b
+native_regions:
+  - region_A
+  - region_b: region_B

--- a/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_b.yaml
+++ b/tests/data/region_processing/wildcard_skip_aggregation/mappings/model_b.yaml
@@ -2,3 +2,7 @@ model: model_b
 native_regions:
   - region_A
   - region_b: region_B
+common_regions:
+  - World:
+    - region_A
+    - region_b

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -37,6 +37,12 @@ def test_variable_multiple_units():
     assert var.unit == ["unit1", "unit2"]
 
 
+def test_variable_wildcard_skip_region_aggregation_required():
+    """Test that a VariableCode with wildcard must have skip_region_aggregation: True"""
+    with raises(ValueError, match="Wildcard variable 'Var1\*' must skip region"):
+        VariableCode.from_dict({"Var1*": {"unit": "unit1"}})
+
+
 @pytest.mark.parametrize("unit", ["Test unit", ["Test unit 1", "Test unit 2"]])
 def test_set_attributes_with_json(unit):
     var = VariableCode(

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -298,9 +298,16 @@ def test_illegal_char_ignores_external_repo():
     """Check that external repos are excluded from this check."""
     # the config includes illegal characters known to be in common-definitions
     # the test will not raise errors as the check is skipped for external repos
-    DataStructureDefinition(
-        MODULE_TEST_DATA_DIR / "illegal_chars" / "char_in_external_repo" / "definitions"
-    )
+
+    try:
+        dsd = DataStructureDefinition(
+            MODULE_TEST_DATA_DIR
+            / "illegal_chars"
+            / "char_in_external_repo"
+            / "definitions"
+        )
+    finally:
+        clean_up_external_repos(dsd.config.repositories)
 
 
 def test_end_whitespace_fails():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -297,6 +297,51 @@ def test_region_processing_skip_aggregation(model_name, region_names):
 
 
 @pytest.mark.parametrize(
+    "model_name, region_names",
+    [("m_a", ("region_A", "region_B")), ("m_b", ("region_A", "region_b"))],
+)
+def test_region_processing_wildcard_skip_aggregation(model_name, region_names):
+    # Testing two cases:
+    # * model "m_a" renames native regions and the world region is skipped
+    # * model "m_b" renames single constituent common regions
+
+    variable = "Capital Cost|Electricity|Solar PV"
+    unit = "USD_2010/kW"
+    test_df = IamDataFrame(
+        pd.DataFrame(
+            [
+                [model_name, "s_a", region_names[0], variable, unit, 1, 2],
+                [model_name, "s_a", region_names[1], variable, unit, 3, 4],
+            ],
+            columns=IAMC_IDX + [2005, 2010],
+        )
+    )
+    add_meta(test_df)
+
+    exp = IamDataFrame(
+        pd.DataFrame(
+            [
+                [model_name, "s_a", "region_A", variable, unit, 1, 2],
+                [model_name, "s_a", "region_B", variable, unit, 3, 4],
+            ],
+            columns=IAMC_IDX + [2005, 2010],
+        )
+    )
+    add_meta(exp)
+
+    obs = process(
+        test_df,
+        dsd := DataStructureDefinition(
+            TEST_DATA_DIR / "region_processing/wildcard_skip_aggregation/dsd"
+        ),
+        processor=RegionProcessor.from_directory(
+            TEST_DATA_DIR / "region_processing/wildcard_skip_aggregation/mappings", dsd
+        ),
+    )
+    assert_iamframe_equal(obs, exp)
+
+
+@pytest.mark.parametrize(
     "input_data, exp_data, warning",
     [
         (  # Variable is available in provided and aggregated data and the same

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -259,8 +259,8 @@ def test_region_processing_weighted_aggregation(folder, exp_df, args, caplog):
 )
 def test_region_processing_skip_aggregation(model_name, region_names):
     # Testing two cases:
-    # * model "m_a" renames native regions and the world region is skipped
-    # * model "m_b" renames single constituent common regions
+    # * model "model_a" renames native regions and the world region is skipped
+    # * model "model_b" renames single constituent common regions
 
     test_df = IamDataFrame(
         pd.DataFrame(
@@ -298,12 +298,12 @@ def test_region_processing_skip_aggregation(model_name, region_names):
 
 @pytest.mark.parametrize(
     "model_name, region_names",
-    [("m_a", ("region_A", "region_B")), ("m_b", ("region_A", "region_b"))],
+    [("model_a", ("region_A", "region_B")), ("model_b", ("region_A", "region_b"))],
 )
 def test_region_processing_wildcard_skip_aggregation(model_name, region_names):
     # Testing two cases:
-    # * model "m_a" renames native regions and the world region is skipped
-    # * model "m_b" renames single constituent common regions
+    # * model "model_a" keeps native regions as they are
+    # * model "model_b" renames one native region
 
     variable = "Capital Cost|Electricity|Solar PV"
     unit = "USD_2010/kW"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,9 +70,9 @@ def test_validation_fails_region(simple_definition, simple_df, caplog):
 def test_validation_multiple_units(extras_definition, simple_df):
     """Validating against a VariableCode with multiple units works as expected"""
     extras_definition.validate(
-        simple_df
-        .filter(variable="Primary Energy|Coal")
-        .rename(unit={"EJ/yr": "GWh/yr"})
+        simple_df.filter(variable="Primary Energy|Coal").rename(
+            unit={"EJ/yr": "GWh/yr"}
+        )
     )
 
 


### PR DESCRIPTION
This PR is an alternative solution to #446, assuming that wildcard-variables should not be aggregated.

So this PR implements the following:
- Require that wildcard-variables have an explicit attribute "skip-region-aggregation: True" to avoid confusion and be forward-compatible in case we ever decide to change this behavior
- Skip common-region-aggregation for any variables that are not explicitly listed in the VariableCodeList (i.e., wildcard variables)
- Deactivate aggregate-check for any variables that are not explicitly listed in the VariableCodeList (i.e., wildcard variables)
 
In the process, I also noticed that the test `test_region_processing_skip_aggregation` passed even though the mapping-file was misspelled (m_a instead of model_a), but because the test looked at skipping aggregation, skip-aggregation and no mapping actually had the same effect. I fixed it anyway

closes #444 
closes #445 