### PR TITLE
Remove redundant illegal character check attribute

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -336,11 +336,7 @@ class CodeList(BaseModel):
 
     def check_illegal_characters(self, config: NomenclatureConfig) -> dict[str, Code]:
         """Check that no illegal characters are left in codes after tag replacement"""
-        illegal = (
-            ["{", "}"] + config.illegal_characters
-            if config.check_illegal_characters
-            else ["{", "}"]
-        )
+        illegal = ["{", "}"] + config.illegal_characters
         errors = ErrorCollector()
 
         def _check_string(value):

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -245,7 +245,6 @@ class NomenclatureConfig(BaseModel):
     repositories: dict[str, Repository] = Field(default_factory=dict)
     definitions: DataStructureConfig = Field(default_factory=DataStructureConfig)
     mappings: RegionMappingConfig = Field(default_factory=RegionMappingConfig)
-    check_illegal_characters: bool = True
     illegal_characters: list[str] = [":", ";", '"']
 
     model_config = ConfigDict(use_enum_values=True)

--- a/tests/data/codelist/illegal_chars/char_in_external_repo/nomenclature.yaml
+++ b/tests/data/codelist/illegal_chars/char_in_external_repo/nomenclature.yaml
@@ -8,5 +8,4 @@ definitions:
   variable:
     repository:
       - common-definitions
-check_illegal_characters: true
 illegal_characters: ["'"]  # these are known to be present in common-definitions variables


### PR DESCRIPTION
The boolean attribute is unnecessary when the list of illegal characters can be empty