### PR TITLE
Refactor multiple warning levels for same data validation filter

### DIFF
--- a/tests/data/validation/validate_data/validate_warning_joined.yaml
+++ b/tests/data/validation/validate_data/validate_warning_joined.yaml
@@ -1,0 +1,12 @@
+ - variable: Primary Energy
+   year: 2010
+   validation:
+    - upper_bound: 5
+      lower_bound: 1
+    - warning_level: low
+      upper_bound: 2.5
+      lower_bound: 1
+ - variable: Primary Energy|Coal
+   year: 2010
+   upper_bound: 5
+   lower_bound: 1

--- a/tests/data/validation/validate_data/validate_warning_separate.yaml
+++ b/tests/data/validation/validate_data/validate_warning_separate.yaml
@@ -1,12 +1,12 @@
  - variable: Primary Energy
    year: 2010
+   upper_bound: 5
+   lower_bound: 1
+ - variable: Primary Energy
+   year: 2010
    upper_bound: 2.5
    lower_bound: 1
    warning_level: low
- - variable: Primary Energy
-   year: 2010
-   upper_bound: 5
-   lower_bound: 1
  - variable: Primary Energy|Coal
    year: 2010
    upper_bound: 5

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -129,25 +129,32 @@ def test_DataValidator_apply_fails(simple_df, file, item_1, item_2, item_3, capl
     assert failed_validation_message in caplog.text
 
 
-def test_DataValidator_validate_with_warning(simple_df, caplog):
+@pytest.mark.parametrize(
+    "file",
+    [
+        "separate",
+        "joined",
+    ],
+)
+def test_DataValidator_validate_with_warning(file, simple_df, caplog):
     data_validator = DataValidator.from_file(
-        DATA_VALIDATION_TEST_DIR / "validate_warning.yaml"
+        DATA_VALIDATION_TEST_DIR / f"validate_warning_{file}.yaml"
     )
     with pytest.raises(ValueError, match="Data validation failed"):
         data_validator.apply(simple_df)
 
     failed_validation_message = (
         "Data validation with error(s)/warning(s) "
-        f"""(file {(DATA_VALIDATION_TEST_DIR / "validate_warning.yaml").relative_to(Path.cwd())}):
-  Criteria: variable: ['Primary Energy'], year: [2010], upper_bound: 2.5, lower_bound: 1.0
-         model scenario region        variable   unit  year  value warning_level
-    0  model_a   scen_a  World  Primary Energy  EJ/yr  2010    6.0           low
-    1  model_a   scen_b  World  Primary Energy  EJ/yr  2010    7.0           low
-
+        f"""(file {(DATA_VALIDATION_TEST_DIR / f"validate_warning_{file}.yaml").relative_to(Path.cwd())}):
   Criteria: variable: ['Primary Energy'], year: [2010], upper_bound: 5.0, lower_bound: 1.0
          model scenario region        variable   unit  year  value warning_level
     0  model_a   scen_a  World  Primary Energy  EJ/yr  2010    6.0         error
-    1  model_a   scen_b  World  Primary Energy  EJ/yr  2010    7.0         error"""
+    1  model_a   scen_b  World  Primary Energy  EJ/yr  2010    7.0         error
+
+  Criteria: variable: ['Primary Energy'], year: [2010], upper_bound: 2.5, lower_bound: 1.0
+         model scenario region        variable   unit  year  value warning_level
+    0  model_a   scen_a  World  Primary Energy  EJ/yr  2010    6.0           low
+    1  model_a   scen_b  World  Primary Energy  EJ/yr  2010    7.0           low"""
     )
 
     # only prints two of three criteria in df to be validated


### PR DESCRIPTION
Closes #439
Allows for a more compact writing of multiple warning level criteria (if warning level is ommitted, it defaults to error). Backwards compatible with more verbose syntax.
Stores the criteria for each level in descending order of severity (useful for upcoming PR that skips validation for lower warnings if a higher one failed).