### PR TITLE
Check if constituents of common regions are in native regions

### DIFF
--- a/nomenclature/error.py
+++ b/nomenclature/error.py
@@ -40,6 +40,10 @@ pydantic_custom_error_config = {
         "region_not_defined",
         "Region(s)\n{regions}\nin {file}\nnot found in RegionCodeList",
     ),
+    "ConstituentsNotNativeError": (
+        "constituents_not_native",
+        "Constituent region(s)\n{regions}\nin {file} not found in RegionCodeList",
+    ),
 }
 
 PydanticCustomErrors = namedtuple("PydanticCustomErrors", pydantic_custom_error_config)

--- a/nomenclature/error.py
+++ b/nomenclature/error.py
@@ -42,7 +42,7 @@ pydantic_custom_error_config = {
     ),
     "ConstituentsNotNativeError": (
         "constituents_not_native",
-        "Constituent region(s)\n{regions}\nin {file} not found in RegionCodeList",
+        "Constituent region(s)\n{regions}\nin {file} not found in native region(s)",
     ),
 }
 

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -228,7 +228,7 @@ class RegionAggregationMapping(BaseModel):
         if v.common_regions and v.native_regions:
             if missing := set(
                 [cr for r in v.common_regions for cr in r.constituent_regions]
-            ).difference([r.name for r in v.native_regions if v.native_regions]):
+            ).difference([r.name for r in v.native_regions]):
                 raise PydanticCustomError(
                     *custom_pydantic_errors.ConstituentsNotNativeError,
                     {"regions": missing, "file": v.file},

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -228,7 +228,7 @@ class RegionAggregationMapping(BaseModel):
         if v.common_regions and v.native_regions:
             if missing := set(
                 [cr for r in v.common_regions for cr in r.constituent_regions]
-            ).difference([r.name for r in v.native_regions]):
+            ).difference([r.name for r in v.native_regions] + v.exclude_regions):
                 raise PydanticCustomError(
                     *custom_pydantic_errors.ConstituentsNotNativeError,
                     {"regions": missing, "file": v.file},

--- a/tests/data/cli/structure_validation_fails/mappings/mapping_2.yaml
+++ b/tests/data/cli/structure_validation_fails/mappings/mapping_2.yaml
@@ -4,4 +4,3 @@ native_regions:
 common_regions:
   - World:
     - region_a
-    - region_b

--- a/tests/data/region_processing/external_repo_test/nomenclature.yaml
+++ b/tests/data/region_processing/external_repo_test/nomenclature.yaml
@@ -4,7 +4,7 @@ dimensions:
 repositories:
   common-definitions:
     url: https://github.com/IAMconsortium/common-definitions.git/
-    hash: cb85704
+    hash: 091c0fe
 definitions:
   region:
     repository: common-definitions

--- a/tests/data/region_processing/external_repo_test_missing_region/nomenclature.yaml
+++ b/tests/data/region_processing/external_repo_test_missing_region/nomenclature.yaml
@@ -4,7 +4,7 @@ dimensions:
 repositories:
   common-definitions:
     url: https://github.com/IAMconsortium/common-definitions.git/
-    hash: cb85704
+    hash: 091c0fe
 definitions:
   region:
     repository:

--- a/tests/data/region_processing/region_aggregation/illegal_mapping_constituent_native_missing.yaml
+++ b/tests/data/region_processing/region_aggregation/illegal_mapping_constituent_native_missing.yaml
@@ -1,0 +1,10 @@
+# Constituent region is not defined in native region
+model: model_a
+native_regions:
+  - region_a: alternative_name_a
+  - region_b: alternative_name_b
+common_regions:
+  - common_region_1:
+    - region_a
+    - region_b
+    - region_c

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -83,6 +83,10 @@ def test_mapping():
             "illegal_mapping_model_only.yaml",
             "one of 'native_regions' and 'common_regions'",
         ),
+        (
+            "illegal_mapping_constituent_native_missing.yaml",
+            "Constituent region\(s\)\n.*\n",
+        ),
     ],
 )
 def test_illegal_mappings(file, error_msg_pattern):
@@ -191,7 +195,7 @@ def test_region_processor_wrong_args():
 
 def test_region_processor_multiple_wrong_mappings(simple_definition):
     # Read in the entire region_aggregation directory and return **all** errors
-    msg = "Collected 9 errors"
+    msg = "Collected 10 errors"
 
     with pytest.raises(ValueError, match=msg):
         RegionProcessor.from_directory(


### PR DESCRIPTION
Closes #443
Constituent regions used for region aggregation should also be native regions, otherwise, unexpected errors may appear (as caught in [this PR](https://github.com/IAMconsortium/common-definitions/pull/247).