### PR TITLE
Remove None defaults from RegionAggregationMapping

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -109,23 +109,11 @@ class RegionAggregationMapping(BaseModel):
 
     model: list[str]
     file: FilePath
-    native_regions: list[NativeRegion] | None = None
-    common_regions: list[CommonRegion] | None = None
-    exclude_regions: list[str] | None = None
+    native_regions: list[NativeRegion] = Field(default_factory=list)
+    common_regions: list[CommonRegion] = Field(default_factory=list)
+    exclude_regions: list[str] = Field(default_factory=list)
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_no_additional_attributes(cls, v):
-        if illegal_additional_attributes := [
-            input_attribute
-            for input_attribute in v.keys()
-            if input_attribute not in cls.model_fields
-        ]:
-            raise ValueError(
-                "Illegal attributes in 'RegionAggregationMapping': "
-                f"{illegal_additional_attributes} (file {v['file']})"
-            )
-        return v
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("model", mode="before")
     @classmethod

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -43,7 +43,7 @@ def test_mapping():
                 "constituent_regions": ["region_c"],
             },
         ],
-        "exclude_regions": None,
+        "exclude_regions": [],
     }
     assert obs.model_dump() == exp
 
@@ -51,10 +51,6 @@ def test_mapping():
 @pytest.mark.parametrize(
     "file, error_msg_pattern",
     [
-        (
-            "illegal_mapping_illegal_attribute.yaml",
-            "Illegal attributes in 'RegionAggregationMapping'",
-        ),
         (
             "illegal_mapping_conflict_regions.yaml",
             "Name collision in native and common regions.*common_region_1",
@@ -92,6 +88,15 @@ def test_illegal_mappings(file, error_msg_pattern):
         RegionAggregationMapping.from_file(TEST_FOLDER_REGION_AGGREGATION / file)
 
 
+def test_illegal_additional_attribute():
+    with pytest.raises(
+        pydantic.ValidationError, match="Extra inputs are not permitted"
+    ):
+        RegionAggregationMapping.from_file(
+            TEST_FOLDER_REGION_AGGREGATION / "illegal_mapping_illegal_attribute.yaml"
+        )
+
+
 def test_mapping_parsing_error():
     with pytest.raises(ValueError, match="string indices must be integers"):
         RegionAggregationMapping.from_file(
@@ -119,15 +124,15 @@ def test_region_processor_working(region_processor_path, simple_definition):
             "native_regions": [
                 {"name": "World", "rename": None},
             ],
-            "common_regions": None,
-            "exclude_regions": None,
+            "common_regions": [],
+            "exclude_regions": [],
         },
         {
             "model": ["model_b"],
             "file": (
                 TEST_FOLDER_REGION_PROCESSING / "regionprocessor_working/mapping_2.yaml"
             ).relative_to(Path.cwd()),
-            "native_regions": None,
+            "native_regions": [],
             "common_regions": [
                 {
                     "name": "World",


### PR DESCRIPTION
Closes #465.

This PR removes the `None` defaults for `native_regions`, `common_regions` and `exclude_regions` and replaces it with empty lists.
This allows us to get rid of some if guards that we had before attempting to iterate over the above lists. As a result, `_apply_region_processing` is now less nested and easier to read.
In addition I also cleaned up `RegionAggregationMapping` a bit making use of some more pydantic native features. The two clean ups are:
* Use `model_config = ConfigDict(extra="forbid")` to prevent additional attributes instead of checking explicitly 
* Refactor `to_yaml` to use serializers for more complex fields.