### PR TITLE
Add `range` validation

### DIFF
--- a/tests/data/validation/validate_data/validate_warning_range.yaml
+++ b/tests/data/validation/validate_data/validate_warning_range.yaml
@@ -1,0 +1,11 @@
+ - variable: Primary Energy
+   year: 2010
+   validation:
+    - range: [ 1, 5 ]
+    - warning_level: low
+      upper_bound: 2.5
+      lower_bound: 1
+ - variable: Primary Energy|Coal
+   year: 2010
+   upper_bound: 5
+   lower_bound: 1

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -137,7 +137,7 @@ def test_DataValidator_apply_fails(simple_df, file, item_1, item_2, item_3, capl
 
 @pytest.mark.parametrize(
     "file, value",
-    [("joined", 6.0), ("joined", 3.0), ("legacy", 6.0)],
+    [("joined", 6.0), ("joined", 3.0), ("legacy", 6.0), ("range", 6.0)],
 )
 def test_DataValidator_validate_with_warning(file, value, simple_df, caplog):
     """Checks that failed validation rows are printed in log."""
@@ -154,6 +154,7 @@ def test_DataValidator_validate_with_warning(file, value, simple_df, caplog):
     0  model_a   scen_a  World  Primary Energy  EJ/yr  2010    6.0         error
     1  model_a   scen_b  World  Primary Energy  EJ/yr  2010    7.0         error"""
     )
+
     if file == "legacy":
         # prints both error and low warning levels for legacy format
         # because these are treated as independent validation-criteria
@@ -163,6 +164,11 @@ def test_DataValidator_validate_with_warning(file, value, simple_df, caplog):
          model scenario region        variable   unit  year  value warning_level
     0  model_a   scen_a  World  Primary Energy  EJ/yr  2010    6.0           low
     1  model_a   scen_b  World  Primary Energy  EJ/yr  2010    7.0           low"""
+
+    if file == "range":
+        failed_validation_message = failed_validation_message.replace(
+            "upper_bound: 5.0, lower_bound: 1.0", "range: [1.0, 5.0]"
+        )
 
     if value == 3.0:
         # prints each warning level when each is triggered by different rows


### PR DESCRIPTION
#471
Adds a `range` attribute to set lower/upper bounds in validation criteria.
Adds a simple test showing it works equivalently to bounds.
Missing test(s) to raise validation error.