### PR TITLE
Use logging-config instead of basicConfig

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -1,7 +1,7 @@
-import logging
+from logging import config, getLogger
 from importlib.metadata import version
 from pathlib import Path
-
+import json
 import yaml
 
 from nomenclature.cli import cli  # noqa
@@ -13,14 +13,14 @@ from nomenclature.definition import SPECIAL_CODELIST, DataStructureDefinition  #
 from nomenclature.processor import RegionAggregationMapping  # noqa
 from nomenclature.processor import RegionProcessor, RequiredDataValidator  # noqa
 
-# set up logging
-logging.basicConfig(
-    format="%(asctime)s %(levelname)-8s %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.INFO,
-)
 
-logger = logging.getLogger(__name__)
+here = Path(__file__).parent
+
+# set up logging
+with open(here / "logging.json") as file:
+    config.dictConfig(json.load(file))
+
+logger = getLogger(__name__)
 
 __version__ = version("nomenclature-iamc")
 

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -1,4 +1,4 @@
-from logging import config, getLogger
+import logging
 from importlib.metadata import version
 from pathlib import Path
 import json
@@ -18,9 +18,9 @@ here = Path(__file__).parent
 
 # set up logging
 with open(here / "logging.json") as file:
-    config.dictConfig(json.load(file))
+    logging.config.dictConfig(json.load(file))
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 __version__ = version("nomenclature-iamc")
 

--- a/nomenclature/logging.json
+++ b/nomenclature/logging.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "generic": {
+      "format": "[%(levelname)s] %(asctime)s - %(name)s: %(message)s",
+      "datefmt": "%H:%M:%S"
+    }
+  },
+  "loggers": {
+    "nomenclature": {
+      "level": "INFO",
+      "handlers": [
+        "console"
+      ]
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "level": "NOTSET",
+      "formatter": "generic"
+    }
+  }
+}


### PR DESCRIPTION
Finally took time to get to the bottom of why my scenario-processing scripts show all httpx-requests-logging... 

This PR harmonizes the logging-setup with ixmp4 and pyam.

FYI @lisahligono