### PR TITLE
Add datetime validation

### DIFF
--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -319,4 +319,7 @@ def cli_validate_scenarios(input_file: Path, definitions: Path, dimensions: list
     ValueError
         If input_file validation fails against specified codelist(s).
     """
-    DataStructureDefinition(definitions, dimensions).validate(IamDataFrame(input_file))
+    df = IamDataFrame(input_file)
+    dsd = DataStructureDefinition(definitions, dimensions)
+    dsd.validate(df)
+    dsd.validate_datetime(df)

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -245,6 +245,11 @@ class RegionMappingConfig(BaseModel):
         return v
 
 
+class TimeConfig(BaseModel):
+    year: bool = True
+    datetime: str = Field(pattern=r"^UTC([+-])(1[0-4]|0?[0-9]):([0-5][0-9])$")
+
+
 class DimensionEnum(str, Enum):
     model = "model"
     scenario = "scenario"
@@ -259,6 +264,7 @@ class NomenclatureConfig(BaseModel):
     definitions: DataStructureConfig = Field(default_factory=DataStructureConfig)
     mappings: RegionMappingConfig = Field(default_factory=RegionMappingConfig)
     illegal_characters: list[str] = [":", ";", '"']
+    time: None | TimeConfig = None
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/tests/data/data_structure_definition/subannual/region/region.yaml
+++ b/tests/data/data_structure_definition/subannual/region/region.yaml
@@ -1,0 +1,2 @@
+- Common:
+  - World

--- a/tests/data/data_structure_definition/subannual/subannual/months.yaml
+++ b/tests/data/data_structure_definition/subannual/subannual/months.yaml
@@ -1,0 +1,24 @@
+- January:
+    duration: 31 / 365
+- February:
+    duration: 28 / 365
+- March:
+    duration: 31 / 365
+- April:
+    duration: 30 / 365
+- May:
+    duration: 31 / 365
+- June:
+    duration: 30 / 365
+- July:
+    duration: 30 / 365
+- August:
+    duration: 31 / 365
+- September:
+    duration: 30 / 365
+- October:
+    duration: 31 / 365
+- November:
+    duration: 30 / 365
+- December:
+   duration: 31 / 365

--- a/tests/data/data_structure_definition/subannual/variable/variable.yaml
+++ b/tests/data/data_structure_definition/subannual/variable/variable.yaml
@@ -1,0 +1,4 @@
+- Primary Energy:
+    unit: EJ/yr
+- Primary Energy|Coal:
+    unit: EJ/yr


### PR DESCRIPTION
Adds datetime validation, based on an initial implementation in [openENTRANCE](https://github.com/openENTRANCE/openentrance/blob/main/definitions/subannual/README.md).