### PR TITLE
Add alias and improve flexibility for `illegal_characters` config attribute

### DIFF
--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -258,7 +258,9 @@ class NomenclatureConfig(BaseModel):
     repositories: dict[str, Repository] = Field(default_factory=dict)
     definitions: DataStructureConfig = Field(default_factory=DataStructureConfig)
     mappings: RegionMappingConfig = Field(default_factory=RegionMappingConfig)
-    illegal_characters: list[str] = Field([":", ";", '"'], alias="illegal-characters")
+    illegal_characters: list[str] = Field(
+        default_factory=lambda: [":", ";", '"'], alias="illegal-characters"
+    )
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -258,7 +258,7 @@ class NomenclatureConfig(BaseModel):
     repositories: dict[str, Repository] = Field(default_factory=dict)
     definitions: DataStructureConfig = Field(default_factory=DataStructureConfig)
     mappings: RegionMappingConfig = Field(default_factory=RegionMappingConfig)
-    illegal_characters: list[str] = [":", ";", '"']
+    illegal_characters: list[str] = Field([":", ";", '"'], alias="illegal-characters")
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/tests/data/codelist/illegal_chars/char_in_external_repo/nomenclature.yaml
+++ b/tests/data/codelist/illegal_chars/char_in_external_repo/nomenclature.yaml
@@ -8,4 +8,4 @@ definitions:
   variable:
     repository:
       - common-definitions
-illegal_characters: ["'"]  # these are known to be present in common-definitions variables
+illegal-characters: ["'"]  # these are known to be present in common-definitions variables

--- a/tests/data/codelist/illegal_chars/char_in_str/nomenclature.yaml
+++ b/tests/data/codelist/illegal_chars/char_in_str/nomenclature.yaml
@@ -1,3 +1,3 @@
 dimensions:
   - variable
-illegal_characters: ['"' , ";"]
+illegal-characters: ['"' , ";"]

--- a/tests/data/config/general-config-only-country/nomenclature.yaml
+++ b/tests/data/config/general-config-only-country/nomenclature.yaml
@@ -3,4 +3,4 @@ dimensions:
 definitions:
   region:
     country: true
-illegal_characters: [";", ":"]
+illegal-characters: [";", ":"]


### PR DESCRIPTION
Quickfix, introduce an alias for the `illegal_characters` attribute to maintain naming consistency in config yaml files. Refactor the field to utilize `default_factory`, to avoid unexpected behaviour (the list was created once when the class was defined, and shared across all `NomenclatureConfig` instances). Update tests to reflect these changes.