### PR TITLE
Fix region aggregation skip

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -260,7 +260,8 @@ def test_region_processing_weighted_aggregation(folder, exp_df, args, caplog):
 def test_region_processing_skip_aggregation(model_name, region_names):
     # Testing two cases:
     # * model "model_a" renames native regions and the world region is skipped
-    # * model "model_b" aggregates single constituent common regions, which are skipped
+    # * model "model_b" aggregates single constituent common regions, which raises
+    # a ValueError due to an empty dataset
 
     test_df = IamDataFrame(
         pd.DataFrame(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -257,7 +257,7 @@ def test_region_processing_weighted_aggregation(folder, exp_df, args, caplog):
     "model_name, region_names",
     [("model_a", ("region_A", "region_B")), ("model_b", ("region_A", "region_b"))],
 )
-def test_region_processing_skip_aggregation(model_name, region_names, caplog):
+def test_region_processing_skip_aggregation(model_name, region_names):
     # Testing two cases:
     # * model "model_a" renames native regions and the world region is skipped
     # * model "model_b" aggregates single constituent common regions, which are skipped
@@ -291,9 +291,9 @@ def test_region_processing_skip_aggregation(model_name, region_names, caplog):
         TEST_DATA_DIR / "region_processing/skip_aggregation/mappings", dsd
     )
     if model_name == "model_b":
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             obs = process(test_df, dsd, processor=processor)
-            assert "returned an empty dataset" in caplog.text
+        assert "returned an empty dataset" in str(excinfo.value)
     else:
         obs = process(test_df, dsd, processor=processor)
         assert_iamframe_equal(obs, exp)


### PR DESCRIPTION
Closes #483.

According to the documentation of `process`, the expected results are:
> Region-processing, which can consist of three parts:
> * Model native regions not listed in the model mapping will be dropped
> * Model native regions can be renamed
> * Aggregation from model native regions to "common regions"

`test_region_processing_skip_aggregation` had as expected results:
```
# Testing two cases:
# * model "model_a" renames native regions and the world region is skipped
# * model "model_b" renames single constituent common regions
```

```yaml
model: model_a
native_regions:
  - region_A
  - region_B
common_regions:
  - World:
    - region_A
    - region_B
```

For `model_a`, the expected result is skipping the World region, _no_ native renaming,
but keeping the native regions in the data.

For `model_b`, mappings are:
```yaml
model: model_b
common_regions:
  - region_A:
    - region_A
  - region_B:
    - region_b
```
We should expect:
1. no native regions (as they are not listed in the mappings);
2. no renamed native regions (because of 1.);
3. aggregation to common regions (in this case, single constituent common regions,
effectively acting as a renaming).

Given `skip-region-aggregation: true` for `Primary Energy`, the final DataFrame
shouldn't include any data for this variable for common regions. Thus, the expected
result is an empty DataFrame.

As it was previously implemented, it would return a DataFrame of renamed regions,
thus breaking the principle of least surprise, as pointed out by @phackstock.

This PR fixes `skip-region-aggregation` behaviour for RegionProcessor,
excluding common regions in the final data when aggregation is skipped, by:
* making the aggregation pipeline the same for single and multiple constituent
common regions
* excluding single constituent common regions with the same name as their native
region

This is likely a breaking change for workflow repos, since, previously, it
preserved native region data, assuming it to be single constituent common region
data (if the names were the same). Now, that data is excluded, and can lead to a
`ValueError` for an empty dataset.