### PR TITLE
Add `rename` to `Aggregator`

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -211,6 +211,7 @@ class VariableCode(Code):
             return v
 
     @field_validator("unit", mode="before")
+    @classmethod
     def convert_none_to_empty_string(cls, v):
         return v if v is not None else ""
 
@@ -223,6 +224,7 @@ class VariableCode(Code):
         return self
 
     @field_validator("components", mode="before")
+    @classmethod
     def cast_variable_components_args(cls, v):
         """Cast "components" list of dicts to a codelist"""
 
@@ -296,6 +298,7 @@ class RegionCode(Code):
     iso3_codes: list[str] | str | None = None
 
     @field_validator("countries", mode="before")
+    @classmethod
     def check_countries(cls, v: list[str], info: ValidationInfo) -> list[str]:
         """Verifies that each country name is defined in `nomenclature.countries`."""
         v = to_list(v)
@@ -309,6 +312,7 @@ class RegionCode(Code):
         return v
 
     @field_validator("iso3_codes")
+    @classmethod
     def check_iso3_codes(cls, v: list[str], info: ValidationInfo) -> list[str]:
         """Verifies that each ISO3 code is valid according to pycountry library."""
         errors = ErrorCollector()

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -239,6 +239,7 @@ class RegionMappingConfig(BaseModel):
         ]
 
     @field_validator("repositories", mode="before")
+    @classmethod
     def convert_to_set_of_repos(cls, v):
         if not isinstance(v, list):
             return [v]

--- a/nomenclature/processor/aggregator.py
+++ b/nomenclature/processor/aggregator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import yaml
 from pyam import IamDataFrame
-from pydantic import BaseModel, field_validator, ValidationInfo
+from pydantic import BaseModel, field_validator, model_validator, ValidationInfo
 from pydantic.types import FilePath
 from pydantic_core import PydanticCustomError
 
@@ -25,12 +25,20 @@ class AggregationItem(BaseModel):
     components: list[str]
 
 
+class RenameItem(BaseModel):
+    """Item used for simple renaming"""
+
+    name: str
+    rename: str
+
+
 class Aggregator(Processor):
     """Aggregation or renaming of an IamDataFrame on a `dimension`"""
 
     file: FilePath
     dimension: str
     aggregate: list[AggregationItem]
+    rename: list[RenameItem]
 
     def apply(self, df: IamDataFrame) -> IamDataFrame:
         """Apply region processing
@@ -59,31 +67,59 @@ class Aggregator(Processor):
             for c in item.components:
                 rename_dict[c] = item.name
 
+        for item in self.rename:
+            rename_dict[item.name] = item.rename
+
         return rename_dict
 
     @field_validator("aggregate")
+    @classmethod
     def validate_target_names(cls, v, info: ValidationInfo):
         _validate_items([item.name for item in v], info, "Duplicate target")
         return v
 
-    @field_validator("aggregate")
-    def validate_components(cls, v, info: ValidationInfo):
-        # components have to be unique for creating rename-mapping (component -> target)
-        all_components = list()
-        for item in v:
-            all_components.extend(item.components)
-        _validate_items(all_components, info, "Duplicate component")
+    @field_validator("rename")
+    @classmethod
+    def validate_rename(cls, v, info: ValidationInfo):
+        _validate_items(
+            [item.name for item in v], info.data["file"], "Duplicate renaming"
+        )
         return v
 
     @field_validator("aggregate")
+    @classmethod
+    def validate_components(cls, v, info: ValidationInfo):
+        """Check components are unique for creating rename-mapping (component -> target)"""
+        all_components = list()
+        for item in v:
+            all_components.extend(item.components)
+        _validate_items(all_components, info.data["file"], "Duplicate component")
+        return v
+
+    @field_validator("aggregate")
+    @classmethod
     def validate_target_vs_components(cls, v, info: ValidationInfo):
-        # guard against having identical target and component
+        """Guard against having identical target and component"""
         _codes = list()
         for item in v:
             _codes.append(item.name)
             _codes.extend(item.components)
-        _validate_items(_codes, info, "Non-unique target and component")
+        _validate_items(_codes, info.data["file"], "Non-unique target and component")
         return v
+
+    @model_validator(mode="after")
+    def validate_aggregate_vs_rename(self):
+        """Check renaming items are not aggregation items"""
+        agg_components = [comp for item in self.aggregate for comp in item.components]
+        agg_targets = [item.name for item in self.aggregate]
+        rename_sources = [item.name for item in self.rename]
+        rename_targets = [item.rename for item in self.rename]
+        _validate_items(
+            agg_components + agg_targets + rename_sources + rename_targets,
+            self.file,
+            "Aggregation items overlapping renaming items",
+        )
+        return self
 
     @property
     def codes(self):
@@ -119,6 +155,9 @@ class Aggregator(Processor):
           - Target Value:
             - Source Value A
             - Source Value B
+        rename:
+          - Source Value C: Target Value
+          - Source Value D: Target Value
 
         """
         file = Path(file) if isinstance(file, str) else file
@@ -127,21 +166,27 @@ class Aggregator(Processor):
                 mapping_input = yaml.safe_load(f)
 
             aggregate_list: list[dict[str, list]] = []
-            for item in mapping_input["aggregate"]:
+            for item in mapping_input.get("aggregate", []):
                 # TODO explicit check that only one key-value pair exists per item
                 aggregate_list.append(
                     dict(name=list(item)[0], components=list(item.values())[0])
+                )
+            rename_list: list[dict[str, list]] = []
+            for item in mapping_input.get("rename", []):
+                rename_list.append(
+                    dict(name=list(item)[0], rename=list(item.values())[0])
                 )
         except Exception as error:
             raise ValueError(f"{error} in {get_relative_path(file)}") from error
         return cls(
             dimension=mapping_input["dimension"],
             aggregate=aggregate_list,  # type: ignore
+            rename=rename_list,
             file=get_relative_path(file),
         )
 
 
-def _validate_items(items, info, _type):
+def _validate_items(items: list, file: str, _type: str):
     duplicates = [item for item, count in Counter(items).items() if count > 1]
     if duplicates:
         raise PydanticCustomError(
@@ -149,6 +194,6 @@ def _validate_items(items, info, _type):
             {
                 "type": _type,
                 "duplicates": duplicates,
-                "file": info.data["file"],
+                "file": file,
             },
         )

--- a/nomenclature/processor/data_validator.py
+++ b/nomenclature/processor/data_validator.py
@@ -38,6 +38,7 @@ class DataValidationCriteria(BaseModel):
     warning_level: WarningEnum = WarningEnum.error
 
     @field_validator("warning_level", mode="before")
+    @classmethod
     def validate_warning_level(cls, value):
         if isinstance(value, str):
             try:
@@ -129,6 +130,7 @@ class DataValidationRange(DataValidationCriteria):
     range: list[float] = Field(..., min_length=2, max_length=2)
 
     @field_validator("range", mode="after")
+    @classmethod
     def check_range_is_valid(cls, value: list[float]):
         if value[0] > value[1]:
             raise ValueError(

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -123,6 +123,7 @@ class RegionAggregationMapping(BaseModel):
         return pyam.utils.to_list(v)
 
     @field_validator("native_regions")
+    @classmethod
     def validate_native_regions_name(cls, v, info: ValidationInfo):
         native_names = [nr.name for nr in v]
         if duplicates := [
@@ -140,6 +141,7 @@ class RegionAggregationMapping(BaseModel):
         return v
 
     @field_validator("native_regions")
+    @classmethod
     def validate_native_regions_target(cls, v, info: ValidationInfo):
         target_names = [nr.target_native_region for nr in v]
         duplicates = [
@@ -158,6 +160,7 @@ class RegionAggregationMapping(BaseModel):
         return v
 
     @field_validator("common_regions")
+    @classmethod
     def validate_common_regions(cls, v, info: ValidationInfo):
         names = [cr.name for cr in v]
         duplicates = [item for item, count in Counter(names).items() if count > 1]

--- a/tests/data/processor/aggregator/aggregation_mapping_rename_conflict.yaml
+++ b/tests/data/processor/aggregator/aggregation_mapping_rename_conflict.yaml
@@ -2,10 +2,7 @@ dimension: variable
 aggregate:
   - Primary Energy:
     - Primary Energy|Coal
-    - Primary Energy|Biomass
   - Final Energy:
-    - Final Energy|Electricity
     - Final Energy|Heat
 rename:
-  - Resource|Extraction|Petrol: Resource|Extraction|Oil
-
+  - Primary Energy: Primary Energy|Biomass

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -31,6 +31,9 @@ def test_aggregator_from_file():
                 "components": ["Final Energy|Electricity", "Final Energy|Heat"],
             },
         ],
+        "rename": [
+            {"name": "Resource|Extraction|Petrol", "rename": "Resource|Extraction|Oil"}
+        ],
     }
     assert obs.model_dump() == exp
 
@@ -49,6 +52,10 @@ def test_aggregator_from_file():
         (
             "aggregation_mapping_target_component_conflict.yaml",
             "Non-unique target and component \['Primary Energy'\] in aggregation-",
+        ),
+        (
+            "aggregation_mapping_rename_conflict.yaml",
+            "Aggregation items overlapping renaming items \['Primary Energy'\] in aggregation-",
         ),
     ],
 )
@@ -98,6 +105,7 @@ def test_aggregator_apply():
                 ["Primary Energy|Biomass", "EJ/yr", 2, 7],
                 ["Final Energy|Electricity", "EJ/yr", 2.5, 3],
                 ["Final Energy|Heat", "EJ/yr", 3, 6],
+                ["Resource|Extraction|Petrol", "EJ/yr", 4, 8],
             ],
             columns=["variable", "unit", 2005, 2010],
         ),
@@ -108,6 +116,7 @@ def test_aggregator_apply():
             [
                 ["Primary Energy", "EJ/yr", 2.5, 10],
                 ["Final Energy", "EJ/yr", 5.5, 9],
+                ["Resource|Extraction|Oil", "EJ/yr", 4, 8],
             ],
             columns=["variable", "unit", 2005, 2010],
         ),


### PR DESCRIPTION
Closes #492
Adds a `rename` option to the `Aggregator` config file as specified in the issue.
Adds sanity check to avoid conficts between aggregation and renaming.
Updates tests accordingly.