### PR TITLE
Fix illegal characters validation

### DIFF
--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -279,7 +279,7 @@ class NomenclatureConfig(BaseModel):
     definitions: DataStructureConfig = Field(default_factory=DataStructureConfig)
     mappings: RegionMappingConfig = Field(default_factory=RegionMappingConfig)
     illegal_characters: list[str] = Field(
-        default_factory=lambda: [":", ";", '"'], alias="illegal-characters"
+        default=[":", ";", '"'], alias="illegal-characters"
     )
     time: TimeDomainConfig = Field(default_factory=TimeDomainConfig)
 

--- a/tests/data/codelist/illegal_chars/no_chars/definitions/variable/variables.yaml
+++ b/tests/data/codelist/illegal_chars/no_chars/definitions/variable/variables.yaml
@@ -1,0 +1,7 @@
+- Primary Energy:
+    definition: Total primary energy consumption
+    unit: EJ/yr
+- Primary Energy|Coal:
+    definition: Primary energy consumption of coal
+    unit: EJ/yr
+    info: Additional info with illegal " character

--- a/tests/data/codelist/illegal_chars/no_chars/nomenclature.yaml
+++ b/tests/data/codelist/illegal_chars/no_chars/nomenclature.yaml
@@ -1,0 +1,3 @@
+dimensions:
+  - variable
+illegal-characters: []

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -294,12 +294,24 @@ def test_stray_tag_fails(subfolder, match):
         code_list.check_illegal_characters(NomenclatureConfig(dimensions=["variable"]))
 
 
-def test_illegal_char_fails():
-    """Check that illegal character raises expected error."""
-    match = r"Illegal character\(s\) '\"' in info of variable 'Primary Energy\|Coal'"
-    with raises(ValueError, match=match):
-        DataStructureDefinition(
-            MODULE_TEST_DATA_DIR / "illegal_chars" / "char_in_str" / "definitions"
+@pytest.mark.parametrize("subfolder", ["char_in_str", "no_chars"])
+def test_illegal_chars_raise_or_ignore(subfolder):
+    """Check that illegal characters raise error if listed, ignored if unlisted."""
+    if subfolder == "char_in_str":
+        match = (
+            r"Illegal character\(s\) '\"' in info of variable 'Primary Energy\|Coal'"
+        )
+        with raises(ValueError, match=match):
+            DataStructureDefinition(
+                MODULE_TEST_DATA_DIR / "illegal_chars" / subfolder / "definitions"
+            )
+    else:
+        # if no illegal characters configured, don't raise validation error
+        assert (
+            DataStructureDefinition(
+                MODULE_TEST_DATA_DIR / "illegal_chars" / subfolder / "definitions"
+            ).config.illegal_characters
+            == []
         )
 
 


### PR DESCRIPTION
Fix field definition that was overriding option to ignore illegal characters.
Added test to reflect this case.