### PR TITLE
Rename "time" to "time-domain" in `NomenclatureConfig` and update tests

### DIFF
--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -282,7 +282,9 @@ class NomenclatureConfig(BaseModel):
     illegal_characters: list[str] = Field(
         default=[":", ";", '"'], alias="illegal-characters"
     )
-    time: TimeDomainConfig = Field(default_factory=TimeDomainConfig)
+    time_domain: TimeDomainConfig = Field(
+        default_factory=TimeDomainConfig, alias="time-domain"
+    )
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/nomenclature/definition.py
+++ b/nomenclature/definition.py
@@ -111,7 +111,7 @@ class DataStructureDefinition:
                 is False
                 for dimension in (dimensions or self.dimensions)
             )
-            or self.config.time.validate_datetime(df) is False
+            or self.config.time_domain.validate_datetime(df) is False
         ):
             raise ValueError("The validation failed. Please check the log for details.")
 

--- a/tests/data/config/datetime_false.yaml
+++ b/tests/data/config/datetime_false.yaml
@@ -1,4 +1,4 @@
-time:
+time-domain:
    year: false
    datetime: false
    timezone: UTC+01:00

--- a/tests/data/config/datetime_true.yaml
+++ b/tests/data/config/datetime_true.yaml
@@ -1,3 +1,3 @@
-time:
+time-domain:
    year: false
    datetime: true

--- a/tests/data/config/datetime_utc.yaml
+++ b/tests/data/config/datetime_utc.yaml
@@ -1,4 +1,4 @@
-time:
+time-domain:
    year: false
    datetime: true
    timezone: UTC+01:00

--- a/tests/data/config/datetime_year.yaml
+++ b/tests/data/config/datetime_year.yaml
@@ -1,2 +1,2 @@
-time:
+time-domain:
    year: true


### PR DESCRIPTION
For consistency with pyam naming convention