### PR TITLE
Only include renamed native-regions in rename mapping

### DIFF
--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -380,7 +380,11 @@ class RegionAggregationMapping(BaseModel):
 
     @property
     def rename_mapping(self) -> dict[str, str]:
-        return {r.name: r.target_native_region for r in self.native_regions or []}
+        return {
+            r.name: r.target_native_region
+            for r in self.native_regions or []
+            if r.rename is not None
+        }
 
     @property
     def upload_native_regions(self) -> list[str]:


### PR DESCRIPTION
This PR fixes an issue experienced by the GCAM team submitting results to the ScenarioMIP (ssp-submission) explorer, where the region-processing produced duplicate data rows following the latest release and the new feature introduced in #495.

The problem is that the new native-region format
```yaml
native_region:
    region_a: Model A|region_a
    region_a
```
translates to the `rename_mapping` dictionary
```python
{
    region_a: None
}
```

So the method `_apply_region_processing()` is correct, just the line
https://github.com/IAMconsortium/nomenclature/blob/0aec90d40428e6677a67bf5ae851cf66ab3ff2bd/nomenclature/processor/region.py#L672
doesn't actually rename the regions in the GCAM case.