### PR TITLE
Add check for infinite values in `process()`

### DIFF
--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -68,7 +68,6 @@ def process(
 
     # check for infinite values in data
     if isinf(df.data["value"]).any():
-        logger.error("Data contains inf or -inf values")
         raise ValueError("Data contains inf or -inf values.")
 
     for p in processor:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -643,6 +643,5 @@ def test_processing_inf_values_raises(simple_df, simple_definition, caplog):
             columns=IAMC_IDX + [2005, 2010],
         )
     )
-    with pytest.raises(ValueError, match = "Data contains inf or -inf values"):
+    with pytest.raises(ValueError, match="Data contains inf or -inf values"):
         process(df_with_inf, simple_definition)
-    assert "Data contains inf or -inf values" in caplog.text


### PR DESCRIPTION
Closes #387
A simple check for infinite values in the `process` function used for workflow repos.