### PR TITLE
Allow scse-toolkit <0.16.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3265,4 +3265,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "a499f8df03189e3369eef4ba682ea3855d2b7b3d9e5dd2ac5518792193f420ba"
+content-hash = "e08ebf8e52dec1b78f86174aee089b4440ce31eb81a4d6cf74994031664f9e6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pysquirrel (>=1.1,<2.0)",
     "gitpython (>=3.1.40,<4.0)",
     "numpy (>=1.23.0,<3.0)",
-    "scse-toolkit (>=0.14.0,<0.15.0)",
+    "scse-toolkit (>=0.14.0,<0.16.0)",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This is required for to https://github.com/iiasa/scse-processing/issues/113 since https://github.com/iiasa/scse-toolkit/pull/47 introduced the required impersonation token feature. This is only available from toolkit version 0.15