### PR TITLE
Validate timeseries data check with `VariableCodeList.validate_df()`

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -713,6 +713,8 @@ class VariableCodeList(CodeList):
         super().validate_df(df, dimension, project)
         # validate units
         self.validate_units(df.unit_mapping, project)
+        # validate timeseries data values
+        self.data_validator.apply(df)
 
     def list_missing_variables(
         self, df: IamDataFrame, file: Path | str | None = None

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -62,10 +62,8 @@ def process(
     ):
         dimensions.remove("region")
 
-    # validate against the codelists and the validation-criteria
+    # validate against the codelists
     dsd.validate(df, dimensions=dimensions)
-    if "variable" in dimensions:
-        dsd.variable.data_validator.apply(df)
 
     # run the processors
     for p in processor:


### PR DESCRIPTION
#539 added the **VariableCodeList.data_validator** to `nomenclature.process()`, but I realize now that in various notebooks, I used 
```python
definition.validate(df)
```
to check for consistency before uploading to a database, not the more elaborate
```python
nomenclature.process(df, definition)
```
(because there are usually no additional processors in my process-and-transfer-scripts).

So this PR moves the **data_validator** to the `validate_df()` method to avoid inadvertently bypassing this check.