### PR TITLE
Add fields for input and output data/meta to processor

### DIFF
--- a/nomenclature/processor/processor.py
+++ b/nomenclature/processor/processor.py
@@ -1,10 +1,16 @@
 import abc
+from typing import Annotated
 
 from pyam import IamDataFrame
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Processor(BaseModel, abc.ABC):
+    input_data: Annotated[dict[str, list[str]] | None, Field(frozen=True)] = None
+    input_meta: Annotated[list[str] | None, Field(frozen=True)] = None
+    output_data: Annotated[dict[str, list[str]] | None, Field(frozen=True)] = None
+    output_meta: Annotated[list[str] | None, Field(frozen=True)] = None
+
     @abc.abstractmethod
     def apply(self, df: IamDataFrame) -> IamDataFrame:
         raise NotImplementedError

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -34,6 +34,10 @@ def test_aggregator_from_file():
         "rename": [
             {"name": "Resource|Extraction|Petrol", "rename": "Resource|Extraction|Oil"}
         ],
+        "input_data": None,
+        "input_meta": None,
+        "output_data": None,
+        "output_meta": None,
     }
     assert obs.model_dump() == exp
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -11,7 +11,7 @@ def test_processor_subclass():
             return df
 
     input_data = {"variable": ["Emissions|CO2"], "region": ["World"]}
-    output_meta = "Emissions Diagnostics|Year of Net Zero|CO2"
+    output_meta = ["Emissions Diagnostics|Year of Net Zero|CO2"]
     processor = ProcessorSubclass(
         input_data=input_data,
         output_meta=output_meta,
@@ -26,4 +26,4 @@ def test_processor_subclass():
     with pytest.raises(ValidationError, match="Field is frozen"):
         processor.input_data = {"variable": ["Emissions|Kyoto Gases"]}
     with pytest.raises(ValidationError, match="Field is frozen"):
-        processor.input_meta = "Emissions Diagnostics|Cumulative CO2 [2020-2100"
+        processor.input_meta = ["Emissions Diagnostics|Cumulative CO2 [2020-2100"]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,29 @@
+from pydantic import ValidationError
+import pytest
+from pyam import IamDataFrame
+
+from nomenclature.processor import Processor
+
+
+def test_processor_subclass():
+    class ProcessorSubclass(Processor):
+        def apply(self, df: IamDataFrame) -> IamDataFrame:
+            return df
+
+    input_data = {"variable": ["Emissions|CO2"], "region": ["World"]}
+    output_meta = "Emissions Diagnostics|Year of Net Zero|CO2"
+    processor = ProcessorSubclass(
+        input_data=input_data,
+        output_meta=output_meta,
+    )
+
+    assert processor.input_data == input_data
+    assert processor.input_meta is None
+    assert processor.output_data is None
+    assert processor.output_meta == output_meta
+
+    # check that frozen fields cannot be modified after instantiation
+    with pytest.raises(ValidationError, match="Field is frozen"):
+        processor.input_data = {"variable": ["Emissions|Kyoto Gases"]}
+    with pytest.raises(ValidationError, match="Field is frozen"):
+        processor.input_meta = "Emissions Diagnostics|Cumulative CO2 [2020-2100"


### PR DESCRIPTION
As a generalization of https://github.com/IAMconsortium/scenariocompass/pull/3, this PR adds fields for input/output meta/data to the **Processor** class.