### PR TITLE
Add country name explicitly as the description

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -899,6 +899,7 @@ class RegionCodeList(CodeList):
                 code_list.append(
                     RegionCode(
                         name=country.name,
+                        description=country.name,
                         iso3_codes=country.alpha_3,
                         hierarchy="Country",
                     )


### PR DESCRIPTION
This extends #598 because otherwise, regions that are created from pysquirrel won't get a long description with the alpha-3 code.