### PR TITLE
Allow `meta` code lists

### DIFF
--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -169,11 +169,10 @@ class CodeList(BaseModel):
         """
         tag_dict: dict[str, list[Code]] = {}
 
-        for yaml_file in (
-            f
-            for f in path.glob(file_glob_pattern)
-            if f.suffix in {".yaml", ".yml"} and f.name.startswith("tag_")
-        ):
+        tag_files = list(path.glob("**/tag_*.yaml")) + list(
+            path.parent.glob("tag_*.yaml")
+        )
+        for yaml_file in (f for f in tag_files):
             with open(yaml_file, "r", encoding="utf-8") as stream:
                 _tag_list = yaml.safe_load(stream)
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -375,6 +375,7 @@ class DimensionEnum(str, Enum):
     variable = "variable"
     region = "region"
     subannual = "subannual"
+    meta = "meta"
 
 
 class NomenclatureConfig(BaseModel):

--- a/tests/data/codelist/tagged_in_parent_folder_codelist/tag_sector.yaml
+++ b/tests/data/codelist/tagged_in_parent_folder_codelist/tag_sector.yaml
@@ -1,0 +1,7 @@
+- Sector:
+  - Energy:
+      definition: energy
+      weight: Energy
+  - Industry:
+      definition: industrial
+      extra: 1

--- a/tests/data/codelist/tagged_in_parent_folder_codelist/tag_source.yaml
+++ b/tests/data/codelist/tagged_in_parent_folder_codelist/tag_source.yaml
@@ -1,0 +1,5 @@
+- Source:
+  - Fossil:
+      definition: fossil fuels
+  - Renewables:
+      definition: renewables

--- a/tests/data/codelist/tagged_in_parent_folder_codelist/variable/foo.yaml
+++ b/tests/data/codelist/tagged_in_parent_folder_codelist/variable/foo.yaml
@@ -1,0 +1,9 @@
+- Final Energy|{Sector}:
+    definition: Final energy consumption in the {Sector} sector
+    unit: EJ
+
+- Final Energy|{Sector}|{Source}:
+    definition: Final energy consumption of {Source} in the {Sector} sector
+    unit: EJ
+    weight: Final Energy|{Sector}
+    extra: "{Sector}"

--- a/tests/test_codelist.py
+++ b/tests/test_codelist.py
@@ -88,10 +88,14 @@ def test_duplicate_tag_raises():
         )
 
 
-def test_tagged_codelist():
+# the "tagged_in_parent_codelist" folder checks that
+@pytest.mark.parametrize(
+    "folder", ("tagged_codelist", "tagged_in_parent_folder_codelist/variable")
+)
+def test_tagged_codelist(folder):
     """Check that multiple tags in a code are correctly replaced"""
     variables = VariableCodeList.from_directory(
-        "variable", MODULE_TEST_DATA_DIR / "tagged_codelist"
+        "variable", MODULE_TEST_DATA_DIR / folder
     )
 
     exp = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,7 +112,7 @@ def test_invalid_config_dimensions_raises():
     with raises(
         ValueError,
         match=(
-            "Input should be 'model', 'scenario', 'variable', 'region' or 'subannual'"
+            "Input should be 'model', .* 'region', 'subannual' or 'meta"
         ),
     ):
         NomenclatureConfig(dimensions=["year"])


### PR DESCRIPTION
For work in **climate-definitions**, I wanted to use codelists of meta-indicators and allow using tag-lists across dimensions, so this PR extends the parsing of tag-files to the parent-folder of the dimensions (usually the `definitions` folder).