### PR TITLE
Separate run workflow for scse processing

### DIFF
--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -1,5 +1,3 @@
-import importlib.util
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -10,6 +8,7 @@ from typing_extensions import Annotated
 
 from nomenclature import __version__
 from nomenclature.codelist import CodeList, VariableCodeList
+from nomenclature.core import run_workflow
 from nomenclature.definition import SPECIAL_CODELIST, DataStructureDefinition
 from nomenclature.processor import RegionAggregationMapping, RegionProcessor
 from nomenclature.testing import assert_valid_structure, assert_valid_yaml
@@ -206,22 +205,6 @@ def list_missing_variables(
 # ---------------------------------------------------------
 # run-workflow
 # ---------------------------------------------------------
-def run_workflow(
-    input_file: Path,
-    workflow_file: Path = (Path.cwd() / "workflow.py"),
-    workflow_function: str = "main",
-) -> IamDataFrame:
-
-    module_name = workflow_file.stem
-    spec = importlib.util.spec_from_file_location(module_name, workflow_file)
-    workflow = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = workflow
-    spec.loader.exec_module(workflow)
-
-    if not hasattr(workflow, workflow_function):
-        raise ValueError(f"{workflow} does not have a function `{workflow_function}`")
-
-    return getattr(workflow, workflow_function)(IamDataFrame(input_file))
 
 
 @app.command("run-workflow")

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -1,12 +1,12 @@
 import importlib.util
 import sys
 from pathlib import Path
-from typing_extensions import Annotated
 
 import pandas as pd
 import typer
 import yaml
 from pyam import IamDataFrame
+from typing_extensions import Annotated
 
 from nomenclature import __version__
 from nomenclature.codelist import CodeList, VariableCodeList
@@ -206,7 +206,6 @@ def list_missing_variables(
 # ---------------------------------------------------------
 # run-workflow
 # ---------------------------------------------------------
-@app.command()
 def run_workflow(
     input_file: Path,
     workflow_file: Path = (Path.cwd() / "workflow.py"),
@@ -322,7 +321,8 @@ def parse_model_registration(
     ] = (Path.cwd() / "definitions" / "region"),
     mappings_path: Annotated[
         Path, typer.Option(exists=True, help="Model mappings output folder")
-    ] = Path.cwd() / "mappings",
+    ] = Path.cwd()
+    / "mappings",
 ) -> None:
     """Parse model registration spreadsheet and generate YAML files.
 

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -232,7 +232,7 @@ def cli_run_workflow(
     Example:
       $ nomenclature run-workflow input.xlsx --output-file output.xlsx
     """
-    df = run_workflow(input_file, workflow_file, workflow_function)
+    df = run_workflow(IamDataFrame(input_file), workflow_file, workflow_function)
     if output_file is not None:
         df.to_excel(output_file)
 

--- a/nomenclature/cli.py
+++ b/nomenclature/cli.py
@@ -208,6 +208,25 @@ def list_missing_variables(
 # ---------------------------------------------------------
 @app.command()
 def run_workflow(
+    input_file: Path,
+    workflow_file: Path = (Path.cwd() / "workflow.py"),
+    workflow_function: str = "main",
+) -> IamDataFrame:
+
+    module_name = workflow_file.stem
+    spec = importlib.util.spec_from_file_location(module_name, workflow_file)
+    workflow = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = workflow
+    spec.loader.exec_module(workflow)
+
+    if not hasattr(workflow, workflow_function):
+        raise ValueError(f"{workflow} does not have a function `{workflow_function}`")
+
+    return getattr(workflow, workflow_function)(IamDataFrame(input_file))
+
+
+@app.command("run-workflow")
+def cli_run_workflow(
     input_file: Annotated[
         Path, typer.Argument(..., exists=True, help="Input IAMC data file")
     ],
@@ -220,7 +239,7 @@ def run_workflow(
     output_file: Annotated[
         Path | None, typer.Option(help="Output file for processed data")
     ] = None,
-):
+) -> None:
     """Execute a custom Python workflow on IAMC data.
 
     Loads a function from a Python file and applies it to process scenario data.
@@ -231,16 +250,7 @@ def run_workflow(
     Example:
       $ nomenclature run-workflow input.xlsx --output-file output.xlsx
     """
-    module_name = workflow_file.stem
-    spec = importlib.util.spec_from_file_location(module_name, workflow_file)
-    workflow = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = workflow
-    spec.loader.exec_module(workflow)
-
-    if not hasattr(workflow, workflow_function):
-        raise ValueError(f"{workflow} does not have a function `{workflow_function}`")
-
-    df: IamDataFrame = getattr(workflow, workflow_function)(IamDataFrame(input_file))
+    df = run_workflow(input_file, workflow_file, workflow_function)
     if output_file is not None:
         df.to_excel(output_file)
 

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -23,6 +23,7 @@ from nomenclature.exceptions import (
     UnknownCodeError,
     UnknownRegionError,
     UnknownScenarioError,
+    UnknownVariableComponentError,
     UnknownVariableError,
     VariableRenameArgError,
     VariableRenameTargetError,

--- a/nomenclature/codelist.py
+++ b/nomenclature/codelist.py
@@ -3,7 +3,7 @@ import re
 from os import PathLike
 from pathlib import Path
 from textwrap import indent
-from typing import Any, IO, ClassVar
+from typing import IO, Any, ClassVar, Self
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,6 @@ from nomenclature.code import Code, MetaCode, RegionCode, VariableCode
 from nomenclature.config import CodeListConfig, NomenclatureConfig
 from nomenclature.exceptions import (
     CodeListErrorGroup,
-    UnknownVariableComponentError,
     MissingWeightError,
     UnknownCodeError,
     UnknownRegionError,
@@ -201,7 +200,7 @@ class CodeList(BaseModel):
         path: Path,
         config: NomenclatureConfig | None = None,
         file_glob_pattern: str = "**/*",
-    ) -> "CodeList":
+    ) -> Self:
         """Initialize a CodeList from a directory with codelist files
 
         Parameters

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -1,6 +1,9 @@
+import importlib.util
 import logging
+import sys
+from pathlib import Path
 
-import pyam
+from pyam import IamDataFrame
 from pydantic import validate_call
 
 from nomenclature.definition import DataStructureDefinition
@@ -12,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 @validate_call(config={"arbitrary_types_allowed": True})
 def process(
-    df: pyam.IamDataFrame,
+    df: IamDataFrame,
     dsd: DataStructureDefinition,
     dimensions: list[str] | str | None = None,
     processor: Processor | list[Processor] | None = None,
-) -> pyam.IamDataFrame:
+) -> IamDataFrame:
     """Function for validation and region aggregation in one step
 
     This function is the recommended way of using the nomenclature package. It performs
@@ -113,3 +116,23 @@ def process(
         )
 
     return df
+
+
+def run_workflow(
+    input_file: Path,
+    workflow_file: Path = (Path.cwd() / "workflow.py"),
+    workflow_function: str = "main",
+) -> IamDataFrame:
+
+    module_name = workflow_file.stem
+    spec = importlib.util.spec_from_file_location(module_name, workflow_file)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load workflow module from {workflow_file}")
+    workflow = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = workflow
+    spec.loader.exec_module(workflow)
+
+    if not hasattr(workflow, workflow_function):
+        raise ValueError(f"{workflow} does not have a function `{workflow_function}`")
+
+    return getattr(workflow, workflow_function)(IamDataFrame(input_file))

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -119,7 +119,7 @@ def process(
 
 
 def run_workflow(
-    input_file: Path,
+    df: IamDataFrame,
     workflow_file: Path = (Path.cwd() / "workflow.py"),
     workflow_function: str = "main",
 ) -> IamDataFrame:
@@ -135,4 +135,4 @@ def run_workflow(
     if not hasattr(workflow, workflow_function):
         raise ValueError(f"{workflow} does not have a function `{workflow_function}`")
 
-    return getattr(workflow, workflow_function)(IamDataFrame(input_file))
+    return getattr(workflow, workflow_function)(df)


### PR DESCRIPTION
This PR separates the "running a workflow" part out of the cli command so that it can be used by scse-processing to directly capture the `IamDataFrame` to save on an additional write and read operation.