### PR TITLE
Allow datetime-items without timezone

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,9 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import nomenclature
 from datetime import datetime
+
+import nomenclature
 
 # -- Project information -----------------------------------------------------
 

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -301,8 +301,8 @@ class TimeDomainConfig(BaseModel):
     def mixed_allowed(self) -> bool:
         return self.year_allowed and self.datetime_allowed
 
-    def check_datetime_format(self, df: IamDataFrame) -> None:
-        """Validate that datetime values conform to configured format and timezone."""
+    def check_datetime_timezone(self, df: IamDataFrame) -> None:
+        """Validate that datetime values use the configured timezone."""
 
         # Only check timezone if a specific timezone is required
         if not self.timezone:
@@ -315,8 +315,9 @@ class TimeDomainConfig(BaseModel):
         ]
         if errors:
             raise TimeDomainErrorGroup(
-                "The following datetime values have an invalid timezone:", errors
+                "The following datetime items have an invalid timezone:", errors
             )
+        return None
 
     def validate_datetime(
         self, df: IamDataFrame, dimensions: list[str] | None = None
@@ -348,14 +349,14 @@ class TimeDomainConfig(BaseModel):
                 raise TimeDomainError(
                     "Invalid time domain - `mixed` found, but not allowed."
                 )
-            self.check_datetime_format(df)
+            self.check_datetime_timezone(df)
 
         elif df.time_domain == "datetime":
             if not self.datetime_allowed:
                 raise TimeDomainError(
                     "Invalid time domain - `datetime` found, but not allowed."
                 )
-            self.check_datetime_format(df)
+            self.check_datetime_timezone(df)
         else:
             raise TimeDomainError(
                 "IamDataFrame.time_domain must be one of ['year', 'mixed', "

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -301,24 +301,14 @@ class TimeDomainConfig(BaseModel):
     def mixed_allowed(self) -> bool:
         return self.year_allowed and self.datetime_allowed
 
-    @property
-    def datetime_format(self) -> str:
-        # If year is a separate column, exclude it from format
-        # If not, datetime is coerced to IamDataFrame, and include seconds
-        return "%Y-%m-%d %H:%M:%S" if self.datetime_allowed else None
-
     def check_datetime_format(self, df: IamDataFrame) -> None:
         """Validate that datetime values conform to configured format and timezone."""
         errors = []
         _datetime = [d for d in df.time if isinstance(d, datetime)]
         for d in _datetime:
-            try:
-                _dt = datetime.strptime(str(d), self.datetime_format + "%z")
-                # Only check timezone if a specific timezone is required
-                if self.timezone and not _dt.tzname() == self.timezone:
-                    errors.append(TimeDomainError(f"{d} - invalid timezone"))
-            except ValueError:
-                errors.append(TimeDomainError(f"{d} - missing timezone"))
+            # Only check timezone if a specific timezone is required
+            if self.timezone and not d.tzname() == self.timezone:
+                errors.append(TimeDomainError(f"{d} - invalid timezone"))
         if errors:
             raise TimeDomainErrorGroup(
                 "The following datetime values are invalid:", errors

--- a/nomenclature/config.py
+++ b/nomenclature/config.py
@@ -303,15 +303,19 @@ class TimeDomainConfig(BaseModel):
 
     def check_datetime_format(self, df: IamDataFrame) -> None:
         """Validate that datetime values conform to configured format and timezone."""
-        errors = []
-        _datetime = [d for d in df.time if isinstance(d, datetime)]
-        for d in _datetime:
-            # Only check timezone if a specific timezone is required
-            if self.timezone and not d.tzname() == self.timezone:
-                errors.append(TimeDomainError(f"{d} - invalid timezone"))
+
+        # Only check timezone if a specific timezone is required
+        if not self.timezone:
+            return None
+
+        errors = [
+            TimeDomainError(f"{d} - invalid timezone") for d in
+            [d for d in df.time if isinstance(d, datetime)]
+            if d.tzname() != self.timezone
+        ]
         if errors:
             raise TimeDomainErrorGroup(
-                "The following datetime values are invalid:", errors
+                "The following datetime values have an invalid timezone:", errors
             )
 
     def validate_datetime(
@@ -344,8 +348,8 @@ class TimeDomainConfig(BaseModel):
                 raise TimeDomainError(
                     "Invalid time domain - `mixed` found, but not allowed."
                 )
-
             self.check_datetime_format(df)
+
         elif df.time_domain == "datetime":
             if not self.datetime_allowed:
                 raise TimeDomainError(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -141,8 +141,8 @@ def test_wildcard_match(simple_df):
     [
         # With datetime=True, not providing a timezone is allowed
         (
-                {2005: "2005-06-17 00:00", 2010: "2010-06-17 00:00"},
-                "datetime_true",
+            {2005: "2005-06-17 00:00", 2010: "2010-06-17 00:00"},
+            "datetime_true",
         ),
         # With datetime=True, any timezone is allowed
         (

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -139,6 +139,11 @@ def test_wildcard_match(simple_df):
 @pytest.mark.parametrize(
     "rename_mapping, config_file_name",
     [
+        # With datetime=True, not providing a timezone is allowed
+        (
+                {2005: "2005-06-17 00:00", 2010: "2010-06-17 00:00"},
+                "datetime_true",
+        ),
         # With datetime=True, any timezone is allowed
         (
             {2005: "2005-06-17 00:00+02:00", 2010: "2010-06-17 00:00+02:00"},
@@ -157,7 +162,7 @@ def test_validate_time_entry(
     rename_mapping,
     config_file_name,
 ):
-    """Test two different datetime values pass the validation"""
+    """Test different datetime values that pass the validation"""
 
     simple_definition.config = NomenclatureConfig.from_file(
         TEST_DATA_DIR / "config" / f"{config_file_name}.yaml"
@@ -183,11 +188,6 @@ def test_validate_time_entry(
             "datetime_utc",
             "invalid timezone",
         ),
-        (
-            {2005: "2005-06-17 00:00", 2010: "2010-06-17 00:00"},
-            "datetime_utc",
-            "missing timezone",
-        ),
     ],
 )
 def test_validate_time_entry_raises(
@@ -197,7 +197,7 @@ def test_validate_time_entry_raises(
     config_file_name,
     match,
 ):
-    """Test three different time validation error cases"""
+    """Test different time validation error cases"""
     simple_definition.config = NomenclatureConfig.from_file(
         TEST_DATA_DIR / "config" / f"{config_file_name}.yaml"
     )


### PR DESCRIPTION
While trying to fix a failed submission attempt by @lindnemi to the **ariadne-dev** instance, I become quite annoyed with the requirement that datetime-items *must* have a timezone even if no timezone is required in the instance config.

This PR removes the error when a datetime-dataset is validated where the datetime-items do not have a timezone. Instead, the datetime-validation only checks the timezone if that is specified in the project config.